### PR TITLE
Log GC events and eagerly initialize initial thread

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -884,6 +884,12 @@ class TimeCollector : public BaseCollector {
             rb_bug("pthread_create");
         }
 
+        // Set the state of the current Ruby thread to RUNNING.
+        // We want to have at least one thread in our thread list because it's
+        // possible that the profile might be such that we don't get any
+        // thread switch events and we need at least one
+        this->threads.set_state(Thread::State::RUNNING);
+
         thread_hook = rb_internal_thread_add_event_hook(internal_thread_event_cb, RUBY_INTERNAL_THREAD_EVENT_MASK, this);
 
         return true;

--- a/test/test_time_collector.rb
+++ b/test/test_time_collector.rb
@@ -14,6 +14,19 @@ class TestTimeCollector < Minitest::Test
     end
   end
 
+  def test_receives_gc_events
+    collector = Vernier::Collector.new(:wall)
+    collector.start
+    GC.start
+    GC.start
+    result = collector.stop
+
+    assert_valid_result result
+    # make sure we got all GC events (since we did GC.start twice)
+    assert_equal ["GC end marking", "GC end sweeping", "GC enter", "GC exit", "GC start"],
+      result.marker_names.uniq.sort
+  end
+
   def test_time_collector
     collector = Vernier::Collector.new(:wall)
     collector.start


### PR DESCRIPTION
This PR has two commits:

1. Record the boot thread state: we should initialize threads with the thread that started Vernier
2. Record GC events

I configured this to use Tracepoint events.  The downside is that it looks like any GC related tracepoint events will cause the GC to do slowpath allocations.

In the allocator, [this conditional](https://github.com/tenderlove/ruby/blob/b41fc9b9a4ad2043a9fabce15814eade9b252569/gc.c#L2810) determines if we should do a slowpath allocation.  That macro simply [looks at `has_hook` on objspace](https://github.com/tenderlove/ruby/blob/b41fc9b9a4ad2043a9fabce15814eade9b252569/gc.c#L2449).  It looks like that boolean will get [set to true for any GC event](https://github.com/tenderlove/ruby/blob/b41fc9b9a4ad2043a9fabce15814eade9b252569/gc.c#L2399-L2405), not just object allocation events.

[Here are the GC lifecycle events and the corresponding mask](https://github.com/tenderlove/ruby/blob/b41fc9b9a4ad2043a9fabce15814eade9b252569/include/ruby/internal/event.h#L92-L100)

That said, I still think we should use the tracepoint events.

1. The tracepoint events are more accurate than trying to inquire the state of the GC (like stackprof does)
2. I think we can fix Ruby to use fastpath allocations even if the GC lifecycle events are on
