### PR TITLE
Refactor marker handling

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1156,7 +1156,9 @@ static VALUE collector_new(VALUE self, VALUE mode) {
     } else {
         rb_raise(rb_eArgError, "invalid mode");
     }
-    return TypedData_Wrap_Struct(self, &rb_collector_type, collector);
+    VALUE obj = TypedData_Wrap_Struct(self, &rb_collector_type, collector);
+    rb_funcall(obj, rb_intern("initialize"), 1, mode);
+    return obj;
 }
 
 extern "C" void

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -452,7 +452,7 @@ class BaseCollector {
         }
     }
 
-    virtual VALUE stop(VALUE self) {
+    virtual VALUE stop() {
         if (!running) {
             rb_raise(rb_eRuntimeError, "collector not running");
         }
@@ -485,19 +485,19 @@ class CustomCollector : public BaseCollector {
         samples.push_back(stack_index);
     }
 
-    VALUE stop(VALUE self) {
-        BaseCollector::stop(self);
+    VALUE stop() {
+        BaseCollector::stop();
 
         frame_list.finalize();
 
-        VALUE result = build_collector_result(self);
+        VALUE result = build_collector_result();
 
         reset();
 
         return result;
     }
 
-    VALUE build_collector_result(VALUE self) {
+    VALUE build_collector_result() {
         VALUE result = rb_obj_alloc(rb_cVernierResult);
 
         VALUE samples = rb_ary_new();
@@ -569,8 +569,8 @@ class RetainedCollector : public BaseCollector {
         return true;
     }
 
-    VALUE stop(VALUE self) {
-        BaseCollector::stop(self);
+    VALUE stop() {
+        BaseCollector::stop();
 
         // GC before we start turning stacks into strings
         rb_gc();
@@ -594,14 +594,14 @@ class RetainedCollector : public BaseCollector {
         rb_tracepoint_disable(tp_freeobj);
         tp_freeobj = Qnil;
 
-        VALUE result = build_collector_result(self);
+        VALUE result = build_collector_result();
 
         reset();
 
         return result;
     }
 
-    VALUE build_collector_result(VALUE self) {
+    VALUE build_collector_result() {
         RetainedCollector *collector = this;
         FrameList &frame_list = collector->frame_list;
 
@@ -987,8 +987,8 @@ class TimeCollector : public BaseCollector {
         return true;
     }
 
-    VALUE stop(VALUE self) {
-        BaseCollector::stop(self);
+    VALUE stop() {
+        BaseCollector::stop();
 
         running = false;
         thread_stopped.wait();
@@ -1011,14 +1011,14 @@ class TimeCollector : public BaseCollector {
 
         frame_list.finalize();
 
-        VALUE result = build_collector_result(self);
+        VALUE result = build_collector_result();
 
         reset();
 
         return result;
     }
 
-    VALUE build_collector_result(VALUE self) {
+    VALUE build_collector_result() {
         VALUE result = rb_obj_alloc(rb_cVernierResult);
 
         VALUE meta = rb_hash_new();
@@ -1127,7 +1127,7 @@ static VALUE
 collector_stop(VALUE self) {
     auto *collector = get_collector(self);
 
-    VALUE result = collector->stop(self);
+    VALUE result = collector->stop();
     return result;
 }
 

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -470,7 +470,7 @@ class BaseCollector {
     };
 
     virtual VALUE get_markers() {
-        return Qnil;
+        return rb_ary_new();
     };
 };
 

--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -12,22 +12,11 @@ module Vernier
   class Result
     attr_reader :weights, :samples, :stack_table, :frame_table, :func_table
     attr_reader :timestamps, :sample_threads, :sample_categories
+    attr_reader :markers
 
     attr_accessor :pid, :start_time, :end_time
     attr_accessor :threads
     attr_accessor :meta
-
-    def marker_names
-      @markers.map { _2 }
-    end
-
-    def marker_threads
-      @markers.map { _1 }
-    end
-
-    def marker_timestamps
-      @markers.map { _3 }
-    end
 
     def started_at
       meta[:started_at]

--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -12,21 +12,14 @@ module Vernier
   class Result
     attr_reader :weights, :samples, :stack_table, :frame_table, :func_table
     attr_reader :timestamps, :sample_threads, :sample_categories
-    attr_reader :marker_timestamps, :marker_threads
-    attr_reader :marker_strings, :marker_ids
+    attr_reader :marker_names, :marker_timestamps, :marker_threads
 
     attr_accessor :pid, :start_time, :end_time
     attr_accessor :threads
     attr_accessor :meta
 
-    private :marker_ids
-
     def started_at
       meta[:started_at]
-    end
-
-    def marker_names
-      marker_ids.map { marker_strings[_1] }
     end
 
     def to_gecko

--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "vernier/version"
+require_relative "vernier/collector"
 require_relative "vernier/vernier"
 require_relative "vernier/output/firefox"
 require_relative "vernier/output/top"

--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -12,14 +12,21 @@ module Vernier
   class Result
     attr_reader :weights, :samples, :stack_table, :frame_table, :func_table
     attr_reader :timestamps, :sample_threads, :sample_categories
-    attr_reader :marker_names, :marker_timestamps, :marker_threads
+    attr_reader :marker_timestamps, :marker_threads
+    attr_reader :marker_strings, :marker_ids
 
     attr_accessor :pid, :start_time, :end_time
     attr_accessor :threads
     attr_accessor :meta
 
+    private :marker_ids
+
     def started_at
       meta[:started_at]
+    end
+
+    def marker_names
+      marker_ids.map { marker_strings[_1] }
     end
 
     def to_gecko

--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -12,11 +12,22 @@ module Vernier
   class Result
     attr_reader :weights, :samples, :stack_table, :frame_table, :func_table
     attr_reader :timestamps, :sample_threads, :sample_categories
-    attr_reader :marker_names, :marker_timestamps, :marker_threads
 
     attr_accessor :pid, :start_time, :end_time
     attr_accessor :threads
     attr_accessor :meta
+
+    def marker_names
+      @markers.map { _2 }
+    end
+
+    def marker_threads
+      @markers.map { _1 }
+    end
+
+    def marker_timestamps
+      @markers.map { _3 }
+    end
 
     def started_at
       meta[:started_at]

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -13,19 +13,11 @@ module Vernier
       result = finish
 
       if @mode == :wall
-        marker_names = []
-        marker_timestamps = []
-        marker_threads = []
-
-        markers.each do |tid, id, ts|
-          marker_names << @marker_strings[id]
-          marker_timestamps << ts
-          marker_threads << tid
+        markers = self.markers.map do |tid, id, ts|
+          [tid, @marker_strings[id], ts]
         end
 
-        result.instance_variable_set(:@marker_timestamps, marker_timestamps)
-        result.instance_variable_set(:@marker_threads, marker_threads)
-        result.instance_variable_set(:@marker_names, marker_names)
+        result.instance_variable_set(:@markers, markers)
       end
 
       result

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -11,42 +11,40 @@ module Vernier
     def stop
       result = finish
 
-      if @mode == :wall
-        markers = []
-        marker_list = self.markers
-        size = marker_list.size
-        marker_strings = Marker.name_table
+      markers = []
+      marker_list = self.markers
+      size = marker_list.size
+      marker_strings = Marker.name_table
 
-        marker_list.each_with_index do |(tid, id, ts), i|
-          name = marker_strings[id]
-          finish = nil
-          phase = Marker::Phase::INSTANT
+      marker_list.each_with_index do |(tid, id, ts), i|
+        name = marker_strings[id]
+        finish = nil
+        phase = Marker::Phase::INSTANT
 
-          if id == Marker::Type::GC_EXIT
-            # skip because these are incorporated in "GC enter"
-          else
-            if id == Marker::Type::GC_ENTER
-              j = i + 1
+        if id == Marker::Type::GC_EXIT
+          # skip because these are incorporated in "GC enter"
+        else
+          if id == Marker::Type::GC_ENTER
+            j = i + 1
 
-              name = "GC pause"
-              phase = Marker::Phase::INTERVAL
+            name = "GC pause"
+            phase = Marker::Phase::INTERVAL
 
-              while j < size
-                if marker_list[j][1] == Marker::Type::GC_EXIT
-                  finish = marker_list[j][2]
-                  break
-                end
-
-                j += 1
+            while j < size
+              if marker_list[j][1] == Marker::Type::GC_EXIT
+                finish = marker_list[j][2]
+                break
               end
+
+              j += 1
             end
-
-            markers << [tid, name, ts, finish, phase]
           end
-        end
 
-        result.instance_variable_set(:@markers, markers)
+          markers << [tid, name, ts, finish, phase]
+        end
       end
+
+      result.instance_variable_set(:@markers, markers)
 
       result
     end

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -13,10 +13,19 @@ module Vernier
       result = finish
 
       if @mode == :wall
+        marker_names = []
+        marker_timestamps = []
+        marker_threads = []
+
+        markers.each do |tid, id, ts|
+          marker_names << @marker_strings[id]
+          marker_timestamps << ts
+          marker_threads << tid
+        end
+
         result.instance_variable_set(:@marker_timestamps, marker_timestamps)
         result.instance_variable_set(:@marker_threads, marker_threads)
-        result.instance_variable_set(:@marker_strings, @marker_strings)
-        result.instance_variable_set(:@marker_ids, marker_ids)
+        result.instance_variable_set(:@marker_names, marker_names)
       end
 
       result

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -6,7 +6,6 @@ module Vernier
   class Collector
     def initialize(mode)
       @mode = mode
-      @marker_strings = Marker.name_table
     end
 
     def stop
@@ -16,9 +15,10 @@ module Vernier
         markers = []
         marker_list = self.markers
         size = marker_list.size
+        marker_strings = Marker.name_table
 
         marker_list.each_with_index do |(tid, id, ts), i|
-          name = @marker_strings[id]
+          name = marker_strings[id]
           finish = nil
           phase = Marker::Phase::INSTANT
 

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "marker"
+
+module Vernier
+  class Collector
+    def initialize(mode)
+      @mode = mode
+      @marker_strings = Marker.name_table
+    end
+  end
+end

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -8,5 +8,18 @@ module Vernier
       @mode = mode
       @marker_strings = Marker.name_table
     end
+
+    def stop
+      result = finish
+
+      if @mode == :wall
+        result.instance_variable_set(:@marker_timestamps, marker_timestamps)
+        result.instance_variable_set(:@marker_threads, marker_threads)
+        result.instance_variable_set(:@marker_strings, @marker_strings)
+        result.instance_variable_set(:@marker_ids, marker_ids)
+      end
+
+      result
+    end
   end
 end

--- a/lib/vernier/marker.rb
+++ b/lib/vernier/marker.rb
@@ -4,6 +4,14 @@ require_relative "vernier" # Make sure constants are loaded
 
 module Vernier
   module Marker
+    # These are equal to the marker phase types from gecko-profile.js
+    module Phase # :nodoc:
+      INSTANT = 0
+      INTERVAL = 1
+      INTERVAL_START = 2
+      INTERVAL_END = 3
+    end
+
     MARKER_STRINGS = []
 
     MARKER_STRINGS[Type::GVL_THREAD_STARTED] = "thread started"

--- a/lib/vernier/marker.rb
+++ b/lib/vernier/marker.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "vernier" # Make sure constants are loaded
+
+module Vernier
+  module Marker
+    MARKER_STRINGS = []
+
+    MARKER_STRINGS[Type::GVL_THREAD_STARTED] = "thread started"
+    MARKER_STRINGS[Type::GVL_THREAD_READY] = "thread ready"
+    MARKER_STRINGS[Type::GVL_THREAD_RESUMED] = "thread resumed"
+    MARKER_STRINGS[Type::GVL_THREAD_SUSPENDED] = "thread suspended"
+    MARKER_STRINGS[Type::GVL_THREAD_EXITED] = "thread exited"
+
+    MARKER_STRINGS[Type::GC_START] = "GC start"
+    MARKER_STRINGS[Type::GC_END_MARK] = "GC end marking"
+    MARKER_STRINGS[Type::GC_END_SWEEP] = "GC end sweeping"
+    MARKER_STRINGS[Type::GC_ENTER] = "GC enter"
+    MARKER_STRINGS[Type::GC_EXIT] = "GC exit"
+
+    MARKER_STRINGS.freeze
+
+    ##
+    # Return an array of marker names.  The index of the string maps to the
+    # value of the corresponding constant
+    def self.name_table
+      MARKER_STRINGS.dup
+    end
+  end
+end

--- a/lib/vernier/marker.rb
+++ b/lib/vernier/marker.rb
@@ -32,7 +32,7 @@ module Vernier
     # Return an array of marker names.  The index of the string maps to the
     # value of the corresponding constant
     def self.name_table
-      MARKER_STRINGS.dup
+      MARKER_STRINGS
     end
   end
 end

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -111,11 +111,13 @@ module Vernier
           thread[:categories] << profile.sample_categories[i]
         end
 
-        profile.marker_names.size.times do |i|
+        marker_names = profile.marker_names
+
+        marker_names.size.times do |i|
           tid = profile.marker_threads[i]
           thread = threads[tid]
 
-          thread[:marker_names] << profile.marker_names[i]
+          thread[:marker_names] << marker_names[i]
           thread[:marker_timestamps] << profile.marker_timestamps[i]
         end
 

--- a/test/test_time_collector.rb
+++ b/test/test_time_collector.rb
@@ -23,8 +23,8 @@ class TestTimeCollector < Minitest::Test
 
     assert_valid_result result
     # make sure we got all GC events (since we did GC.start twice)
-    assert_equal ["GC end marking", "GC end sweeping", "GC enter", "GC exit", "GC start"],
-      result.marker_names.uniq.sort
+    assert_equal ["GC end marking", "GC end sweeping", "GC pause", "GC start"].sort,
+      result.markers.map { |x| x[1] }.uniq.sort
   end
 
   def test_time_collector


### PR DESCRIPTION
This PR refactors the way we handle markers.  My main goal was to make the profiler instance responsible for reconciling GC markers.  Now we can add an "add marker" interface to the collector so that users can add custom markers to their profiles.

One change of note is that I moved the `stop` method to Ruby, and change the C++ implementation to a private method called `finish`.

I also exposed the marker type enum in Ruby and pulled the marker name string literals in to Ruby as well.

I added an `initialize` method to the collector object so we can initialize a Ruby array for custom markers (right now it just keeps the profile type as an ivar).