### PR TITLE
Teach the profiler about interval markers

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -559,6 +559,23 @@ class Marker {
     TimeStamp timestamp;
     TimeStamp finish;
     native_thread_id_t thread_id;
+
+    VALUE to_array() {
+        VALUE record[5] = {0};
+        record[0] = ULL2NUM(thread_id);
+        record[1] = INT2NUM(type);
+        record[2] = INT2NUM(phase);
+        record[3] = ULL2NUM(timestamp.nanoseconds());
+
+        if (phase == Marker::Phase::INTERVAL) {
+            record[4] = ULL2NUM(finish.nanoseconds());
+        }
+        else {
+            record[4] = Qnil;
+        }
+
+        return rb_ary_new_from_values(5, record);
+    }
 };
 
 class MarkerTable {
@@ -1003,18 +1020,7 @@ class TimeCollector : public BaseCollector {
         VALUE list = rb_ary_new();
 
         for (auto& marker: this->markers.list) {
-            VALUE record[5] = {0};
-            record[0] = ULL2NUM(marker.thread_id);
-            record[1] = INT2NUM(marker.type);
-            record[2] = INT2NUM(marker.phase);
-            record[3] = ULL2NUM(marker.timestamp.nanoseconds());
-            if (marker.phase == Marker::Phase::INTERVAL) {
-              record[4] = ULL2NUM(marker.finish.nanoseconds());
-            }
-            else {
-              record[4] = Qnil;
-            }
-            rb_ary_push(list, rb_ary_new_from_values(5, record));
+            rb_ary_push(list, marker.to_array());
         }
 
         return list;

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -47,38 +47,12 @@ module Vernier
     def stop
       result = finish
 
-      markers = []
-      marker_list = self.markers
-      size = marker_list.size
       marker_strings = Marker.name_table
 
-      marker_list.each_with_index do |(tid, id, ts), i|
-        name = marker_strings[id]
-        sym = Marker::MARKER_SYMBOLS[id]
-        finish = nil
-        phase = Marker::Phase::INSTANT
-
-        if id == Marker::Type::GC_EXIT
-          # skip because these are incorporated in "GC enter"
-        else
-          if id == Marker::Type::GC_ENTER
-            j = i + 1
-
-            name = "GC pause"
-            phase = Marker::Phase::INTERVAL
-
-            while j < size
-              if marker_list[j][1] == Marker::Type::GC_EXIT
-                finish = marker_list[j][2]
-                break
-              end
-
-              j += 1
-            end
-          end
-
-          markers << [tid, name, sym, ts, finish, phase]
-        end
+      markers = self.markers.map do |(tid, type, phase, ts, te)|
+        name = marker_strings[type]
+        sym = Marker::MARKER_SYMBOLS[type]
+        [tid, name, sym, ts, te, phase]
       end
 
       markers.concat @markers

--- a/lib/vernier/marker.rb
+++ b/lib/vernier/marker.rb
@@ -4,14 +4,6 @@ require_relative "vernier" # Make sure constants are loaded
 
 module Vernier
   module Marker
-    # These are equal to the marker phase types from gecko-profile.js
-    module Phase # :nodoc:
-      INSTANT = 0
-      INTERVAL = 1
-      INTERVAL_START = 2
-      INTERVAL_END = 3
-    end
-
     MARKER_SYMBOLS = []
     Type.constants.each do |name|
       MARKER_SYMBOLS[Type.const_get(name)] = name
@@ -31,6 +23,7 @@ module Vernier
     MARKER_STRINGS[Type::GC_END_SWEEP] = "GC end sweeping"
     MARKER_STRINGS[Type::GC_ENTER] = "GC enter"
     MARKER_STRINGS[Type::GC_EXIT] = "GC exit"
+    MARKER_STRINGS[Type::GC_PAUSE] = "GC pause"
 
     MARKER_STRINGS.freeze
 


### PR DESCRIPTION
This PR teaches the profiler about different marker types including interval markers.  The profiler will now natively record an interval type for GC pauses.  This way we can reduce the post processing required when producing a profile.