### PR TITLE
Add vernier CLI

### DIFF
--- a/bin/vernier
+++ b/bin/vernier
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+load "#{__dir__}/../exe/vernier"

--- a/exe/vernier
+++ b/exe/vernier
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+
+banner = <<-END
+Usage: vernier run [FLAGS] -- COMMAND
+
+FLAGS:
+END
+
+options = {}
+parser = OptionParser.new(banner) do |o|
+  o.on('--output [FILENAME]', String, "output filename") do |s|
+    options[:output] = s
+  end
+  o.on('--interval [MICROSECONDS]', Integer, "sampling interval (default 500)") do |i|
+    options[:interval] = i
+  end
+  o.on('--signal [NAME]', String, "specify a signal to start and stop the profiler") do |s|
+    options[:signal] = s
+  end
+  o.on('--start-paused', "don't automatically start the profiler") do
+    options[:start_paused] = true
+  end
+end
+
+parser.parse!
+parser.abort(parser.help) if ARGV.shift != "run"
+parser.abort(parser.help) if ARGV.empty?
+
+env = {}
+options.each do |k, v|
+  env["VERNIER_#{k.to_s.upcase}"] = v.to_s
+end
+vernier_path = File.expand_path('../lib', __dir__)
+env['RUBYOPT'] = "-I #{vernier_path} -r vernier/autorun #{ENV['RUBYOPT']}"
+
+Kernel.exec(env, *ARGV)

--- a/lib/vernier/autorun.rb
+++ b/lib/vernier/autorun.rb
@@ -1,0 +1,63 @@
+require "tempfile"
+require "vernier"
+
+module Vernier
+  module Autorun
+    class << self
+      attr_accessor :collector
+      attr_reader :options
+    end
+    @collector = nil
+
+    @options = ENV.to_h.select { |k,v| k.start_with?("VERNIER_") }
+    @options.transform_keys! do |key|
+      key.sub(/\AVERNIER_/, "").downcase.to_sym
+    end
+    @options.freeze
+
+    def self.start
+      interval = options.fetch(:interval, 500).to_i
+
+      STDERR.puts("starting profiler with interval #{interval}")
+
+      @collector = Vernier::Collector.new(:wall, interval:)
+      @collector.start
+    end
+
+    def self.stop
+      result = @collector.stop
+      @collector = nil
+      output_path = options[:output]
+      output_path ||= Tempfile.create(["profile", ".vernier.json"]).path
+      File.write(output_path, Vernier::Output::Firefox.new(result).output)
+      STDERR.puts("profile written to #{output_path}")
+    end
+
+    def self.running?
+      !!@collector
+    end
+
+    def self.at_exit
+      stop if running?
+    end
+
+    def self.toggle
+      running? ? stop : start
+    end
+  end
+end
+
+unless Vernier::Autorun.options[:start_paused]
+  Vernier::Autorun.start
+end
+
+if signal = Vernier::Autorun.options[:signal]
+  STDERR.puts "to toggle profiler: kill -#{signal} #{Process.pid}"
+  trap(signal) do
+    Vernier::Autorun.toggle
+  end
+end
+
+at_exit do
+  Vernier::Autorun.at_exit
+end


### PR DESCRIPTION
Based heavily on the stackprof CLI + @tenderlove's signal-based toggling

```
$ bin/vernier --help
Usage: vernier run [FLAGS] -- COMMAND

FLAGS:
        --output [FILENAME]          output filename
        --interval [MICROSECONDS]    sampling interval (default 500)
        --signal [NAME]              specify a signal to start and stop the profiler
        --start-paused               don't automatically start the profiler

$ bin/vernier run --output profile.json --interval=1000 -- ruby -e 'sleep 1'
starting profiler with interval 1000
profile written to profile.json
```