### PR TITLE
Put thread markers in their own category

### DIFF
--- a/lib/vernier/marker.rb
+++ b/lib/vernier/marker.rb
@@ -12,11 +12,11 @@ module Vernier
 
     MARKER_STRINGS = []
 
-    MARKER_STRINGS[Type::GVL_THREAD_STARTED] = "thread started"
-    MARKER_STRINGS[Type::GVL_THREAD_READY] = "thread ready"
-    MARKER_STRINGS[Type::GVL_THREAD_RESUMED] = "thread resumed"
-    MARKER_STRINGS[Type::GVL_THREAD_SUSPENDED] = "thread suspended"
-    MARKER_STRINGS[Type::GVL_THREAD_EXITED] = "thread exited"
+    MARKER_STRINGS[Type::GVL_THREAD_STARTED] = "Thread started"
+    MARKER_STRINGS[Type::GVL_THREAD_READY] = "Thread ready"
+    MARKER_STRINGS[Type::GVL_THREAD_RESUMED] = "Thread resumed"
+    MARKER_STRINGS[Type::GVL_THREAD_SUSPENDED] = "Thread suspended"
+    MARKER_STRINGS[Type::GVL_THREAD_EXITED] = "Thread exited"
 
     MARKER_STRINGS[Type::GC_START] = "GC start"
     MARKER_STRINGS[Type::GC_END_MARK] = "GC end marking"

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -16,7 +16,7 @@ module Vernier
           add_category(name: "Default", color: "grey")
           add_category(name: "Idle", color: "transparent")
 
-          @gc_category = add_category(name: "GC", color: "red")
+          add_category(name: "GC", color: "red")
           add_category(
             name: "stdlib",
             color: "red",
@@ -41,6 +41,8 @@ module Vernier
             name: "Application",
             color: "purple"
           )
+
+          add_category(name: "Thread", color: "grey")
         end
 
         def add_category(name:, **kw)
@@ -251,7 +253,15 @@ module Vernier
             # Please don't hate me. Divide by 1,000,000 only if finish is not nil
             end_times << (finish&./(1_000_000.0))
             phases << phase
-            categories << (name =~ /GC/ ? gc_category.idx : 0)
+
+            category = case name
+            when /\AGC/ then gc_category.idx
+            when /\AThread/ then thread_category.idx
+            else
+              0
+            end
+
+            categories << category
             data << { type: sym }
           end
 
@@ -377,6 +387,10 @@ module Vernier
 
         def gc_category
           @categorizer.get_category("GC")
+        end
+
+        def thread_category
+          @categorizer.get_category("Thread")
         end
       end
     end


### PR DESCRIPTION
Help clean up the marker chart so that Thread events are separate from generic events