### PR TITLE
Started threads should be considered "running"

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -724,6 +724,7 @@ class Thread {
 
             switch (new_state) {
                 case State::STARTED:
+                    new_state = State::RUNNING;
                     break;
                 case State::RUNNING:
                     assert(state == State::READY);


### PR DESCRIPTION
We used to only sample running threads because started threads didn't have the full VM set yet.  In PR #18, we changed the event we listen for, and when that event is fired it should be safe to collect samples. This patch makes "started" threads considered as "running" so we'll get those samples.