### PR TITLE
Make `record_interval` use "UserTiming" marker

### DIFF
--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -246,7 +246,7 @@ module Vernier
           categories = []
           data = []
 
-          @markers.each_with_index do |(_, name, sym, start, finish, phase), i|
+          @markers.each_with_index do |(_, name, start, finish, phase, datum), i|
             string_indexes << @strings[name]
             start_times << (start / 1_000_000.0)
 
@@ -262,7 +262,7 @@ module Vernier
             end
 
             categories << category
-            data << { type: sym }
+            data << datum
           end
 
           {

--- a/test/output/test_firefox.rb
+++ b/test/output/test_firefox.rb
@@ -150,6 +150,6 @@ class TestOutputFirefox < Minitest::Test
     assert_valid_firefox_profile(output)
 
     markers = JSON.parse(output)["threads"].flat_map { _1["markers"]["data"] }
-    assert_includes markers, {"type" => "custom"}
+    assert_includes markers, {"type"=>"UserTiming", "entryType"=>"measure", "name"=>"custom"}
   end
 end


### PR DESCRIPTION
If we use the UserTiming marker type, then the user timing bar can optionally be displayed on the stack chart

Here's a sample usage:

```ruby
require "vernier"

def sieve max
  sieve = []
  for i in 2 .. max
    sieve[i] = i
  end

  for i in 2 .. Math.sqrt(max)
    next unless sieve[i]
    (i*i).step(max, i) do |j|
      sieve[j] = nil
    end
  end

  sieve.compact
end

Vernier.trace(out: "time_profile.json") { |v|
  2.times.map {
    Thread.new {
      3.times do |i|
        GC.start
        v.record_interval "sieve", "Iteration #{i}" do
          sleep 0.1
          v.record_interval "sieve2", "Iteration #{i}" do
            sieve(5000000)
          end
        end
      end
    }
  }.map(&:join)
}
```

<img width="1649" alt="Ruby:Vernier – 8:22:2023, 7:11:06 PM UTC – Firefox Profiler 2023-08-22 12-18-47" src="https://github.com/jhawthorn/vernier/assets/3124/47a72abd-9e53-42bd-9318-9403e55c9bf9">
