### PR TITLE
Skip emitting empty STALLED markers

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -131,6 +131,14 @@ class TimeStamp {
         return value_ns >= other.value_ns;
     }
 
+    bool operator==(const TimeStamp &other) const {
+        return value_ns == other.value_ns;
+    }
+
+    bool operator!=(const TimeStamp &other) const {
+        return value_ns != other.value_ns;
+    }
+
     uint64_t nanoseconds() const {
         return value_ns;
     }
@@ -728,7 +736,12 @@ class Thread {
                     break;
                 case State::RUNNING:
                     assert(state == State::READY);
-                    markers->record_interval(Marker::Type::MARKER_THREAD_STALLED, from, now);
+
+                    // If the GVL is immediately ready, and we measure no times
+                    // stalled, skip emitting the interval.
+                    if (from != now) {
+			    markers->record_interval(Marker::Type::MARKER_THREAD_STALLED, from, now);
+		    }
                     break;
                 case State::READY:
                     // The ready state means "I would like to do some work, but I can't


### PR DESCRIPTION
If the GVL is immediately available, avoid emitting a 0-length marker.

**Before:**
<img width="1236" alt="Screenshot 2023-08-23 at 10 46 22 PM" src="https://github.com/jhawthorn/vernier/assets/131752/1729c422-aa7c-4df4-9d4f-4d43cca922df">

**After:**
<img width="1101" alt="Screenshot 2023-08-23 at 10 42 07 PM" src="https://github.com/jhawthorn/vernier/assets/131752/73b0e65a-182e-41e5-96e4-c932446b6c69">

(which makes me wonder if we should skip 0-length suspended/running as well)
