### PR TITLE
Allow `Vernier.trace` to write output file even when exception is raised within block

### DIFF
--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -19,11 +19,11 @@ module Vernier
       yield collector
     ensure
       result = collector.stop
+      if out
+        File.write(out, Output::Firefox.new(result).output)
+      end
     end
 
-    if out
-      File.write(out, Output::Firefox.new(result).output)
-    end
     result
   end
 

--- a/test/test_time_collector.rb
+++ b/test/test_time_collector.rb
@@ -123,6 +123,20 @@ class TestTimeCollector < Minitest::Test
     assert_in_epsilon 400, outer_result.weights.sum, generous_epsilon
   end
 
+  ExpectedError = Class.new(StandardError)
+  def test_raised_exceptions_will_output
+    output_file = File.join(__dir__, "../tmp/exception_output.json")
+
+    result = nil
+    assert_raises(ExpectedError) do
+      Vernier.trace(out: output_file) do
+        raise ExpectedError
+      end
+    end
+
+    assert File.exist?(output_file)
+  end
+
   def generous_epsilon
     if ENV["GITHUB_ACTIONS"] && ENV["RUNNER_OS"] == "macOS"
       # Timing on macOS Actions runners seem extremely unpredictable


### PR DESCRIPTION
I am not sure of the validity of the resulting trace, but I would like this to work because I would love visibility into a failing test case that's shaped like this:

```ruby
Vernier.trace(out: "tmp/trace.json") do
  wrap_something do |intermediate_result|
    assert intermediate_result # <- this raises
  end
end
```