### PR TITLE
Remove unused var and redundant raise in `Vernier::Output::Firefox`

### DIFF
--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -237,8 +237,6 @@ module Vernier
         end
 
         def markers_table
-          size = @markers.size
-
           string_indexes = []
           start_times = []
           end_times = []
@@ -292,7 +290,6 @@ module Vernier
             times = (0...size).to_a
           end
 
-          raise unless samples.size == size
           raise unless weights.size == size
           raise unless times.size == size
 


### PR DESCRIPTION
I ran into this failure when trying this tool out using `Ruby 3.2.2`.

```ruby

/Users/[redacted]/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/warning-1.3.0/lib/warning.rb:260:in `warn': /Users/[redacted]/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/vernier-0.3.0/lib/vernier/output/firefox.rb:240: warning: assigned but unused variable - size (RuntimeError)
        from /Users/[redacted]/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/vernier-0.3.0/lib/vernier.rb:7:in `require_relative'
        from /Users/[redacted]/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/vernier-0.3.0/lib/vernier.rb:7:in `<top (required)>'
        from <internal:/Users/[redacted]/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/[redacted]/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        ...
rake aborted!
Command failed with status (1)
/Users/[redacted]/.rbenv/versions/3.2.2/bin/bundle:25:in `load'
/Users/[redacted]/.rbenv/versions/3.2.2/bin/bundle:25:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```

This PR removes the unused var and also removes a redundant raise I noticed.