### PR TITLE
Require Ruby 3.2.1+

### DIFF
--- a/vernier.gemspec
+++ b/vernier.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary
   spec.homepage = "https://github.com/jhawthorn/vernier"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.2.1"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
3.2.0 has a bug that cause `rb_profile_frames` to not be async signal safe: https://github.com/ruby/ruby/pull/7116

It has been backported in 3.2.1, so might as well prevent the installation of the gem.

Fix: https://github.com/jhawthorn/vernier/issues/42

cc @m-zielinski, @jhawthorn 