### PR TITLE
Update README to emphasize Ruby version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Rails benchmark - lobste.rs (time)
 `require "irb"` (retained memory)
 : https://share.firefox.dev/3DhLsFa
 
+## Requirements
+
+Vernier requires Ruby version 3.2.1 or higher. Please ensure your Ruby environment meets this requirement before installation.
+
 ## Installation
 
 ```ruby


### PR DESCRIPTION
This change adds the minimum Ruby version requirement so that users do not spend time wondering why the Vernier traces are malformed and fail to render in the profile viewers ☺️ 