### PR TITLE
Permit thread state SUSPENDED to go to STOPPED

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -853,8 +853,8 @@ class Thread {
                     markers->record_interval(Marker::Type::MARKER_THREAD_RUNNING, from, now);
                     break;
                 case State::STOPPED:
-                    // We can go from RUNNING or STARTED to STOPPED
-                    assert(state == State::RUNNING || state == State::STARTED);
+                    // We can go from RUNNING or STARTED or SUSPENDED to STOPPED
+                    assert(state == State::RUNNING || state == State::STARTED || state == State::SUSPENDED);
                     markers->record_interval(Marker::Type::MARKER_THREAD_RUNNING, from, now);
                     markers->record(Marker::Type::MARKER_GVL_THREAD_EXITED);
 


### PR DESCRIPTION
TLDR; Otherwise you can have exception like :

```
Assertion Failed: vernier.cc:857:set_state:state == State::RUNNING || state == State::STARTED
```
---

I wanted to plug Vernier to the [benchmark](https://github.com/speedshop/threadbench) mentioned here https://github.com/rails/rails/issues/50450. While trying to plug it, I was stop by an exception from Vernier. I modified the code to permit this handling of state and I was able to [get a result](https://share.firefox.dev/3vSXggu).

It is maybe a mistake from when I tried to setup Vernier on this project. It [can be seen here](https://github.com/speedshop/threadbench/compare/main...benoittgt:threadbench:3.3?expand=1#diff-5fe74a7aca8668f86d1251d17e23b3ac9c55504d8d78698a8168a9cae87b350c).

I am not sure we want to permit this, or instead raise and error for invalid code ?

Full stacktrace can be see here: https://github.com/speedshop/threadbench/commit/7e992f2774ab197640c02a14405eee635939a45f

