### PR TITLE
Pretty thread names based on best-effort parsing of Thread#inspect output

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -859,7 +859,6 @@ class Thread {
                     markers->record(Marker::Type::MARKER_GVL_THREAD_EXITED);
 
                     stopped_at = now;
-                    capture_name();
 
                     break;
             }
@@ -870,13 +869,6 @@ class Thread {
 
         bool running() {
             return state != State::STOPPED;
-        }
-
-        void capture_name() {
-            //char buf[128];
-            //int rc = pthread_getname_np(pthread_id, buf, sizeof(buf));
-            //if (rc == 0)
-            //    name = std::string(buf);
         }
 
         void mark() {
@@ -945,8 +937,12 @@ class ThreadTable {
                     thread.set_state(new_state);
 
                     if (thread.state == Thread::State::RUNNING) {
+                        // rb_inspect should be safe here, as RUNNING should correspond to RESUMED hook from internal_thread_event_cb
+                        // which is called with GVL per https://github.com/ruby/ruby/blob/v3_3_0/include/ruby/thread.h#L247-L248
+                        VALUE thread_str  = rb_inspect(th);
                         thread.pthread_id = pthread_self();
                         thread.native_tid = get_native_thread_id();
+                        thread.name = StringValueCStr(thread_str);
                     } else {
                         thread.pthread_id = 0;
                         thread.native_tid = 0;
@@ -1495,13 +1491,6 @@ class TimeCollector : public BaseCollector {
         rb_internal_thread_remove_event_hook(thread_hook);
         rb_remove_event_hook(internal_gc_event_cb);
         rb_remove_event_hook(internal_thread_event_cb);
-
-        // capture thread names
-        for (auto& thread: this->threads.list) {
-            if (thread.running()) {
-                thread.capture_name();
-            }
-        }
 
         frame_list.finalize();
 

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -859,6 +859,7 @@ class Thread {
                     markers->record(Marker::Type::MARKER_GVL_THREAD_EXITED);
 
                     stopped_at = now;
+                    capture_name();
 
                     break;
             }
@@ -869,6 +870,13 @@ class Thread {
 
         bool running() {
             return state != State::STOPPED;
+        }
+
+        void capture_name() {
+            //char buf[128];
+            //int rc = pthread_getname_np(pthread_id, buf, sizeof(buf));
+            //if (rc == 0)
+            //    name = std::string(buf);
         }
 
         void mark() {
@@ -937,12 +945,8 @@ class ThreadTable {
                     thread.set_state(new_state);
 
                     if (thread.state == Thread::State::RUNNING) {
-                        // rb_inspect should be safe here, as RUNNING should correspond to RESUMED hook from internal_thread_event_cb
-                        // which is called with GVL per https://github.com/ruby/ruby/blob/v3_3_0/include/ruby/thread.h#L247-L248
-                        VALUE thread_str  = rb_inspect(th);
                         thread.pthread_id = pthread_self();
                         thread.native_tid = get_native_thread_id();
-                        thread.name = StringValueCStr(thread_str);
                     } else {
                         thread.pthread_id = 0;
                         thread.native_tid = 0;
@@ -1491,6 +1495,13 @@ class TimeCollector : public BaseCollector {
         rb_internal_thread_remove_event_hook(thread_hook);
         rb_remove_event_hook(internal_gc_event_cb);
         rb_remove_event_hook(internal_thread_event_cb);
+
+        // capture thread names
+        for (auto& thread: this->threads.list) {
+            if (thread.running()) {
+                thread.capture_name();
+            }
+        }
 
         frame_list.finalize();
 

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -387,8 +387,12 @@ module Vernier
 
         def pretty_name(name)
           if name.empty?
-            tr = ObjectSpace._id2ref(@ruby_thread_id)
-            name = tr.inspect if tr
+            begin
+              tr = ObjectSpace._id2ref(@ruby_thread_id)
+              name = tr.inspect if tr
+            rescue RangeError
+              # Thread was already GC'd
+            end
           end
           return name unless name.start_with?("#<Thread")
           pretty = []

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -163,7 +163,7 @@ module Vernier
           @profile = profile
           @categorizer = categorizer
           @tid = tid
-          @name = name
+          @name = pretty_name(name)
 
           timestamps ||= [0] * samples.size
           @samples, @weights, @timestamps = samples, weights, timestamps
@@ -384,6 +384,20 @@ module Vernier
         end
 
         private
+
+        def pretty_name(name)
+          if name.empty?
+            tr = ObjectSpace._id2ref(@ruby_thread_id)
+            name = tr.inspect if tr
+          end
+          return name unless name.start_with?("#<Thread")
+          pretty = []
+          obj_address = name[/Thread:(0x\d+)/,1]
+          best_id = name[/\#<Thread:0x\w+@?\s?(.*)\s+\S+>/,1]
+          pretty << best_id unless best_id.empty?
+          pretty << "(#{obj_address})"
+          pretty.join(' ')
+        end
 
         def gc_category
           @categorizer.get_category("GC")


### PR DESCRIPTION
# Problem

It looks like nothing sets the thread name in the output anymore, so the tracks in firefox-profiler will not show any name:

<img width="314" alt="Screenshot 2024-02-23 at 1 24 39 PM" src="https://github.com/dalehamel/vernier/assets/618615/6bcfa4d7-68f1-4e34-a890-7cb299107579">

Checking out the json file that is going into this, the thread name is "". If no name was ever set, this is expected. However if a name was set, it is still not making it to the gecko output.

I originally suspected https://github.com/jhawthorn/vernier/pull/46, but this is happening for me (on ruby 3.3.0) even with older gems (0.3.0, 0.3.1) that tried to get it from the pthread. In any case, the code to get this from the native extension is [currently commented out](https://github.com/jhawthorn/vernier/blob/v0.4.0/ext/vernier/vernier.cc#L875-L880) and nothing seems to set it anywhere.

# Proposed solution

As @casperisfine has pointed out, calling "inspect" on a `Thread` object gives us a lot of useful information, including the thread name if it is set. So, even though we cannot directly get the name from the native extension, we should be able to inspect the thread objects we already have access to.

However, we need to be careful about this as calling `rb_inspect` requires the GVL is acquired. Within the native extension then, after our callback is fired for `RUBY_INTERNAL_THREAD_EVENT_RESUMED`, we should be able to safely call it. We will just directly store the result as the thread's "name" if we are able to do so.

If we were never able to set this within the native code before we attempt to get the gecko output, we'll try looking up the thread via its object id and calling inspect from ruby land. Either way, the output will be fed into a `pretty_name` function to try and display the name as nicely as possible:

- Prefer to have the thread name as the left-most value, followed by the path if specified
- Trim the gem directories from the paths, if they were set, so they won't be quite as long


With this proposed change, here is what the output looks like:

<img width="609" alt="Screenshot 2024-02-26 at 3 36 41 PM" src="https://github.com/jhawthorn/vernier/assets/618615/348a5bf7-17bc-41f2-8e5a-37198983153d">
