### PR TITLE
Move `:out` and `:gc` to collector

### DIFF
--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -5,8 +5,14 @@ require_relative "thread_names"
 
 module Vernier
   class Collector
-    def initialize(mode, options={})
+    def initialize(mode, options = {})
+      if options.fetch(:gc, true) && (mode == :retained)
+        GC.start
+      end
+
       @mode = mode
+      @out = options[:out]
+
       @markers = []
       @hooks = []
 
@@ -98,6 +104,10 @@ module Vernier
       markers.concat @markers
 
       result.instance_variable_set(:@markers, markers)
+
+      if @out
+        result.write(out: @out)
+      end
 
       result
     end


### PR DESCRIPTION
Adresses:
- https://github.com/jhawthorn/vernier/pull/59#discussion_r1546944913
- https://github.com/jhawthorn/vernier/pull/59#discussion_r1546945557

Another change in behaviour worth mentioning is that `GC.start` now runs after [this initialisation](https://github.com/jhawthorn/vernier/blob/b608919298e2c67f16e137b0cdd23947812f40e3/ext/vernier/vernier.cc#L1714-L1739), whereas before it preceded it.