### PR TITLE
Expose StackTable to Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "rake-compiler"
+gem "benchmark-ips"
 
 gem "minitest", "~> 5.0"

--- a/examples/measure_overhead.rb
+++ b/examples/measure_overhead.rb
@@ -1,0 +1,39 @@
+require "benchmark/ips"
+require "vernier"
+
+def compare(**options, &block)
+  block.call
+
+  Benchmark.ips do |x|
+    x.report "no profiler" do |n|
+      n.times do
+        block.call
+      end
+    end
+
+    x.report "vernier" do |n|
+      Vernier.profile(**options) do
+        n.times do
+          block.call
+        end
+      end
+    end
+
+    x.compare!
+  end
+end
+
+compare do
+  i = 0
+  while i < 10_000
+    i += 1
+  end
+end
+
+compare(allocation_sample_rate: 1000) do
+  Object.new
+end
+
+compare(allocation_sample_rate: 1) do
+  Object.new
+end

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -608,10 +608,20 @@ stack_table_to_h(VALUE self) {
 }
 
 static VALUE
-stack_table_current_stack(VALUE self) {
+stack_table_current_stack(int argc, VALUE *argv, VALUE self) {
+    int offset;
+    VALUE offset_v;
+
+    rb_scan_args(argc, argv, "01", &offset_v);
+    if (argc > 0) {
+        offset = NUM2INT(offset_v) + 1;
+    } else {
+        offset = 1;
+    }
+
     StackTable *stack_table = get_stack_table(self);
     RawSample stack;
-    stack.sample(1);
+    stack.sample(offset);
     int stack_index = stack_table->stack_index(stack);
     return INT2NUM(stack_index);
 }
@@ -1871,7 +1881,7 @@ Init_vernier(void)
   rb_cStackTable = rb_define_class_under(rb_mVernier, "StackTable", rb_cObject);
   rb_undef_alloc_func(rb_cStackTable);
   rb_define_singleton_method(rb_cStackTable, "new", stack_table_new, 0);
-  rb_define_method(rb_cStackTable, "current_stack", stack_table_current_stack, 0);
+  rb_define_method(rb_cStackTable, "current_stack", stack_table_current_stack, -1);
   rb_define_method(rb_cStackTable, "to_h", stack_table_to_h, 0);
 
   Init_consts(rb_mVernierMarkerPhase);

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -409,21 +409,6 @@ struct StackTable {
     private:
 
     std::mutex mutex;
-    std::unordered_map<std::string, int> string_to_idx;
-    std::vector<std::string> string_list;
-
-    int string_index(const std::string str) {
-        auto it = string_to_idx.find(str);
-        if (it == string_to_idx.end()) {
-            int idx = string_list.size();
-            string_list.push_back(str);
-
-            auto result = string_to_idx.insert({str, idx});
-            it = result.first;
-        }
-
-        return it->second;
-    }
 
     struct FrameWithInfo {
         Frame frame;
@@ -535,13 +520,11 @@ struct StackTable {
     void clear() {
         const std::lock_guard<std::mutex> lock(mutex);
 
-        string_list.clear();
         frame_list.clear();
         stack_node_list.clear();
         func_list.clear();
         func_info_list.clear();
 
-        string_to_idx.clear();
         frame_to_idx.clear();
         func_to_idx.clear();
         root_stack_node.children.clear();

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -857,7 +857,6 @@ class SampleList {
 
         std::vector<int> stacks;
         std::vector<TimeStamp> timestamps;
-        std::vector<native_thread_id_t> threads;
         std::vector<Category> categories;
         std::vector<int> weights;
 
@@ -869,11 +868,10 @@ class SampleList {
             return size() == 0;
         }
 
-        void record_sample(int stack_index, TimeStamp time, native_thread_id_t thread_id, Category category) {
+        void record_sample(int stack_index, TimeStamp time, Category category) {
             if (
                     !empty() &&
                     stacks.back() == stack_index &&
-                    threads.back() == thread_id &&
                     categories.back() == category)
             {
                 // We don't compare timestamps for de-duplication
@@ -881,7 +879,6 @@ class SampleList {
             } else {
                 stacks.push_back(stack_index);
                 timestamps.push_back(time);
-                threads.push_back(thread_id);
                 categories.push_back(category);
                 weights.push_back(1);
             }
@@ -1201,8 +1198,7 @@ class CustomCollector : public BaseCollector {
         sample.sample();
         int stack_index = stack_table->stack_index(sample);
 
-	native_thread_id_t thread_id = 0;
-        samples.record_sample(stack_index, TimeStamp::Now(), thread_id, CATEGORY_NORMAL);
+        samples.record_sample(stack_index, TimeStamp::Now(), CATEGORY_NORMAL);
     }
 
     VALUE stop() {
@@ -1500,7 +1496,6 @@ class TimeCollector : public BaseCollector {
             thread.samples.record_sample(
                     stack_index,
                     time,
-                    thread.native_tid,
                     category
                     );
         }
@@ -1559,7 +1554,6 @@ class TimeCollector : public BaseCollector {
                     thread.samples.record_sample(
                             thread.stack_on_suspend_idx,
                             sample_start,
-                            thread.native_tid,
                             CATEGORY_IDLE);
                 } else {
                 }

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -505,10 +505,11 @@ struct StackTable {
     }
 
     void write_result(VALUE result) {
+        Check_Type(result, T_HASH);
         StackTable &frame_list = *this;
 
         VALUE stack_table = rb_hash_new();
-        rb_ivar_set(result, rb_intern("@stack_table"), stack_table);
+        rb_hash_aset(result, sym("stack_table"), stack_table);
         VALUE stack_table_parent = rb_ary_new();
         VALUE stack_table_frame = rb_ary_new();
         rb_hash_aset(stack_table, sym("parent"), stack_table_parent);
@@ -520,7 +521,7 @@ struct StackTable {
         }
 
         VALUE frame_table = rb_hash_new();
-        rb_ivar_set(result, rb_intern("@frame_table"), frame_table);
+        rb_hash_aset(result, sym("frame_table"), frame_table);
         VALUE frame_table_func = rb_ary_new();
         VALUE frame_table_line = rb_ary_new();
         rb_hash_aset(frame_table, sym("func"), frame_table_func);
@@ -534,7 +535,7 @@ struct StackTable {
 
         // TODO: dedup funcs before this step
         VALUE func_table = rb_hash_new();
-        rb_ivar_set(result, rb_intern("@func_table"), func_table);
+        rb_hash_aset(result, sym("func_table"), func_table);
         VALUE func_table_name = rb_ary_new();
         VALUE func_table_filename = rb_ary_new();
         VALUE func_table_first_line = rb_ary_new();
@@ -1155,7 +1156,10 @@ class CustomCollector : public BaseCollector {
 	rb_hash_aset(threads, ULL2NUM(0), thread_hash);
 	rb_hash_aset(thread_hash, sym("tid"), ULL2NUM(0));
 
-        frame_list.write_result(result);
+        VALUE stack_table_hash = rb_hash_new();
+        frame_list.write_result(stack_table_hash);
+        rb_ivar_set(result, rb_intern("@stack_table"), stack_table_hash);
+
 
         return result;
     }
@@ -1284,7 +1288,9 @@ class RetainedCollector : public BaseCollector {
             }
         }
 
-        frame_list.write_result(result);
+        VALUE stack_table_hash = rb_hash_new();
+        frame_list.write_result(stack_table_hash);
+        rb_ivar_set(result, rb_intern("@stack_table"), stack_table_hash);
 
         return result;
     }
@@ -1675,7 +1681,9 @@ class TimeCollector : public BaseCollector {
 
         }
 
-        frame_list.write_result(result);
+        VALUE stack_table_hash = rb_hash_new();
+        frame_list.write_result(stack_table_hash);
+        rb_ivar_set(result, rb_intern("@stack_table"), stack_table_hash);
 
         return result;
     }

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -241,10 +241,6 @@ bool operator==(const FrameInfo& lhs, const FrameInfo& rhs) noexcept {
 struct Frame {
     VALUE frame;
     int line;
-
-    FrameInfo info() const {
-        return FrameInfo(frame);
-    }
 };
 
 bool operator==(const Frame& lhs, const Frame& rhs) noexcept {

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -405,6 +405,8 @@ struct LiveSample {
 };
 
 struct StackTable {
+    private:
+
     std::unordered_map<std::string, int> string_to_idx;
     std::vector<std::string> string_list;
 
@@ -455,19 +457,6 @@ struct StackTable {
     StackNode root_stack_node;
     vector<StackNode> stack_node_list;
 
-    int stack_index(const RawSample &stack) {
-        if (stack.empty()) {
-            throw std::runtime_error("VERNIER BUG: empty stack");
-        }
-
-        StackNode *node = &root_stack_node;
-        for (int i = 0; i < stack.size(); i++) {
-            Frame frame = stack.frame(i);
-            node = next_stack_node(node, frame);
-        }
-        return node->index;
-    }
-
     StackNode *next_stack_node(StackNode *node, Frame frame) {
         auto search = node->children.find(frame);
         if (search == node->children.end()) {
@@ -484,6 +473,21 @@ struct StackTable {
             int node_idx = search->second;
             return &stack_node_list[node_idx];
         }
+    }
+
+    public:
+
+    int stack_index(const RawSample &stack) {
+        if (stack.empty()) {
+            throw std::runtime_error("VERNIER BUG: empty stack");
+        }
+
+        StackNode *node = &root_stack_node;
+        for (int i = 0; i < stack.size(); i++) {
+            Frame frame = stack.frame(i);
+            node = next_stack_node(node, frame);
+        }
+        return node->index;
     }
 
     // Converts Frames from stacks other tables. "Symbolicates" the frames
@@ -562,6 +566,8 @@ struct StackTable {
             rb_ary_push(func_table_first_line, INT2NUM(first_line));
         }
     }
+
+    friend class SampleTranslator;
 };
 
 static void

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -469,6 +469,7 @@ struct StackTable {
 
     StackNode root_stack_node;
     vector<StackNode> stack_node_list;
+    int stack_node_list_finalized_idx = 0;
 
     StackNode *next_stack_node(StackNode *node, Frame frame) {
         auto search = node->children.find(frame);
@@ -510,9 +511,11 @@ struct StackTable {
     void finalize() {
         {
             const std::lock_guard<std::mutex> lock(stack_mutex);
-            for (const auto &stack_node : stack_node_list) {
+            for (int i = stack_node_list_finalized_idx; i < stack_node_list.size(); i++) {
+                const auto &stack_node = stack_node_list[i];
                 frame_map.index(stack_node.frame);
                 func_map.index(stack_node.frame.frame);
+                stack_node_list_finalized_idx = i;
             }
         }
 

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -266,7 +266,7 @@ namespace std {
 
 // A basic semaphore built on sem_wait/sem_post
 // post() is guaranteed to be async-signal-safe
-class SamplerSemaphore {
+class SignalSafeSemaphore {
 #ifdef __APPLE__
     dispatch_semaphore_t sem;
 #else
@@ -275,7 +275,7 @@ class SamplerSemaphore {
 
     public:
 
-    SamplerSemaphore(unsigned int value = 0) {
+    SignalSafeSemaphore(unsigned int value = 0) {
 #ifdef __APPLE__
         sem = dispatch_semaphore_create(value);
 #else
@@ -283,7 +283,7 @@ class SamplerSemaphore {
 #endif
     };
 
-    ~SamplerSemaphore() {
+    ~SignalSafeSemaphore() {
 #ifdef __APPLE__
         dispatch_release(sem);
 #else
@@ -366,7 +366,7 @@ struct RawSample {
 struct LiveSample {
     RawSample sample;
 
-    SamplerSemaphore sem_complete;
+    SignalSafeSemaphore sem_complete;
 
     // Wait for a sample to be collected by the signal handler on another thread
     void wait() {
@@ -1333,7 +1333,7 @@ class TimeCollector : public BaseCollector {
     pthread_t sample_thread;
 
     atomic_bool running;
-    SamplerSemaphore thread_stopped;
+    SignalSafeSemaphore thread_stopped;
 
     TimeStamp interval;
     unsigned int allocation_sample_rate;

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1179,11 +1179,6 @@ class CustomCollector : public BaseCollector {
 	rb_hash_aset(threads, ULL2NUM(0), thread_hash);
 	rb_hash_aset(thread_hash, sym("tid"), ULL2NUM(0));
 
-        VALUE stack_table_hash = rb_hash_new();
-        stack_table->write_result(stack_table_hash);
-        rb_ivar_set(result, rb_intern("@stack_table"), stack_table_hash);
-
-
         return result;
     }
 
@@ -1316,10 +1311,6 @@ class RetainedCollector : public BaseCollector {
                 rb_ary_push(weights, INT2NUM(rb_obj_memsize_of(obj)));
             }
         }
-
-        VALUE stack_table_hash = rb_hash_new();
-        frame_list.write_result(stack_table_hash);
-        rb_ivar_set(result, rb_intern("@stack_table"), stack_table_hash);
 
         return result;
     }
@@ -1710,10 +1701,6 @@ class TimeCollector : public BaseCollector {
             rb_hash_aset(hash, sym("is_main"), thread->is_main() ? Qtrue : Qfalse);
 
         }
-
-        VALUE stack_table_hash = rb_hash_new();
-        stack_table->write_result(stack_table_hash);
-        rb_ivar_set(result, rb_intern("@stack_table"), stack_table_hash);
 
         return result;
     }

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1792,6 +1792,13 @@ collector_sample(VALUE self) {
     return Qtrue;
 }
 
+static VALUE
+collector_stack_table(VALUE self) {
+    auto *collector = get_collector(self);
+
+    return collector->stack_table_value;
+}
+
 static VALUE collector_new(VALUE self, VALUE mode, VALUE options) {
     BaseCollector *collector;
 
@@ -1870,6 +1877,7 @@ Init_vernier(void)
   rb_define_singleton_method(rb_cVernierCollector, "_new", collector_new, 2);
   rb_define_method(rb_cVernierCollector, "start", collector_start, 0);
   rb_define_method(rb_cVernierCollector, "sample", collector_sample, 0);
+  rb_define_method(rb_cVernierCollector, "stack_table", collector_stack_table, 0);
   rb_define_private_method(rb_cVernierCollector, "finish",  collector_stop, 0);
   rb_define_private_method(rb_cVernierCollector, "markers",  markers, 0);
 

--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -2,6 +2,7 @@
 
 require_relative "vernier/version"
 require_relative "vernier/collector"
+require_relative "vernier/stack_table"
 require_relative "vernier/result"
 require_relative "vernier/hooks"
 require_relative "vernier/vernier"

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -69,6 +69,7 @@ module Vernier
     def stop
       result = finish
 
+      result.instance_variable_set("@stack_table", stack_table.to_h)
       @thread_names.finish
 
       @hooks.each do |hook|

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -237,20 +237,18 @@ module Vernier
 
           lines = profile.frame_table.fetch(:line)
 
-          @frame_implementations = filenames.zip(lines).map do |filename, line|
+          func_implementations = filenames.map do |filename|
             # Must match strings in `src/profile-logic/profile-data.js`
             # inside the firefox profiler. See `getFriendlyStackTypeName`
             if filename == "<cfunc>"
               @strings["native"]
             else
-              # FIXME: We need to get upstream support for JIT frames
-              if line == -1
-                @strings["yjit"]
-              else
-                # nil means interpreter
-                nil
-              end
+              # nil means interpreter
+              nil
             end
+          end
+          @frame_implementations = profile.frame_table.fetch(:func).map do |func_idx|
+            func_implementations[func_idx]
           end
 
           func_categories = filenames.map do |filename|

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -253,8 +253,11 @@ module Vernier
             end
           end
 
-          @frame_categories = filenames.map do |filename|
+          func_categories = filenames.map do |filename|
             @categorizer.categorize(filename)
+          end
+          @frame_categories = profile.frame_table.fetch(:func).map do |func_idx|
+            func_categories[func_idx]
           end
         end
 

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -325,12 +325,14 @@ module Vernier
             end_times << (finish&./(1_000_000.0))
             phases << phase
 
-            category = case name
-            when /\AGC/ then gc_category.idx
-            when /\AThread/ then thread_category.idx
-            else
-              0
-            end
+            category =
+              if name.start_with?("GC")
+                gc_category.idx
+              elsif name.start_with?("Thread")
+                thread_category.idx
+              else
+                0
+              end
 
             categories << category
             data << datum

--- a/lib/vernier/result.rb
+++ b/lib/vernier/result.rb
@@ -1,6 +1,17 @@
 module Vernier
   class Result
-    attr_reader :stack_table, :frame_table, :func_table
+    def stack_table
+      @stack_table[:stack_table]
+    end
+
+    def frame_table
+      @stack_table[:frame_table]
+    end
+
+    def func_table
+      @stack_table[:func_table]
+    end
+
     attr_reader :markers
 
     attr_accessor :hooks

--- a/lib/vernier/stack_table.rb
+++ b/lib/vernier/stack_table.rb
@@ -1,0 +1,24 @@
+module Vernier
+  class StackTable
+    def backtrace(stack_idx)
+      hash = to_h
+
+      full_stack = []
+      cur_stack_idx = stack_idx
+      while cur_stack_idx
+        full_stack << cur_stack_idx
+        cur_stack_idx = hash[:stack_table][:parent][cur_stack_idx]
+      end
+
+      full_stack.map do |stack_idx|
+        frame_idx = hash[:stack_table][:frame][stack_idx]
+        func_idx = hash[:frame_table][:func][frame_idx]
+        line = hash[:frame_table][:line][frame_idx]
+        name = hash[:func_table][:name][func_idx]
+        filename = hash[:func_table][:filename][func_idx]
+
+        "#{filename}:#{line}:in '#{name}'"
+      end
+    end
+  end
+end

--- a/lib/vernier/stack_table.rb
+++ b/lib/vernier/stack_table.rb
@@ -1,5 +1,23 @@
 module Vernier
   class StackTable
+    def to_h
+      {
+        stack_table: {
+          parent: stack_count.times.map { stack_parent_idx(_1) },
+          frame:  stack_count.times.map { stack_frame_idx(_1) }
+        },
+        frame_table: {
+          func: frame_count.times.map { frame_func_idx(_1) },
+          line:  frame_count.times.map { frame_line_no(_1) }
+        },
+        func_table: {
+          name: func_count.times.map { func_name(_1) },
+          filename: func_count.times.map { func_filename(_1) },
+          first_line: func_count.times.map { func_first_lineno(_1) }
+        }
+      }
+    end
+
     def backtrace(stack_idx)
       full_stack(stack_idx).map do |stack_idx|
         frame_idx = stack_frame_idx(stack_idx)

--- a/lib/vernier/stack_table.rb
+++ b/lib/vernier/stack_table.rb
@@ -1,24 +1,24 @@
 module Vernier
   class StackTable
     def backtrace(stack_idx)
-      hash = to_h
-
-      full_stack = []
-      cur_stack_idx = stack_idx
-      while cur_stack_idx
-        full_stack << cur_stack_idx
-        cur_stack_idx = hash[:stack_table][:parent][cur_stack_idx]
-      end
-
-      full_stack.map do |stack_idx|
-        frame_idx = hash[:stack_table][:frame][stack_idx]
-        func_idx = hash[:frame_table][:func][frame_idx]
-        line = hash[:frame_table][:line][frame_idx]
-        name = hash[:func_table][:name][func_idx]
-        filename = hash[:func_table][:filename][func_idx]
+      full_stack(stack_idx).map do |stack_idx|
+        frame_idx = stack_frame_idx(stack_idx)
+        func_idx = frame_func_idx(frame_idx)
+        line = frame_line_no(frame_idx)
+        name = func_name(func_idx);
+        filename = func_filename(func_idx);
 
         "#{filename}:#{line}:in '#{name}'"
       end
+    end
+
+    def full_stack(stack_idx)
+      full_stack = []
+      while stack_idx
+        full_stack << stack_idx
+        stack_idx = stack_parent_idx(stack_idx)
+      end
+      full_stack
     end
   end
 end

--- a/test/firefox_test_helpers.rb
+++ b/test/firefox_test_helpers.rb
@@ -25,6 +25,22 @@ module FirefoxTestHelpers
       assert thread["stackTable"]
       assert thread["stringArray"]
 
+      string_array = thread["stringArray"]
+      thread["funcTable"]["name"].each do |idx|
+        assert_kind_of Integer, idx
+        assert idx < string_array.size
+      end
+      thread["funcTable"]["fileName"].each do |idx|
+        assert_kind_of Integer, idx
+        assert idx < string_array.size
+      end
+
+      thread["frameTable"]["implementation"].each do |idx|
+        next if idx.nil?
+        assert_kind_of Integer, idx
+        assert idx < string_array.size
+      end
+
       assert thread["markers"]
 
       markers = thread["markers"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,8 @@ ENV["MT_CPU"] = "0"
 require "minitest/autorun"
 
 class Minitest::Test
+  make_my_diffs_pretty!
+
   def assert_valid_result(result)
     assert_equal result.samples.length, result.weights.length
 

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -101,4 +101,16 @@ class TestStackTable < Minitest::Test
 
     assert_operator collector.stack_table.to_h[:stack_table][:parent].size, :>, caller_locations.size+1
   end
+
+  def test_timer_and_manual_samples
+    collector = Vernier::Collector.new(:wall, sample_rate: 10)
+    collector.start
+
+    stack_table = collector.stack_table
+    100_000.times do |i|
+      eval("stack_table.current_stack", binding, "(eval)", i)
+    end
+
+    collector.stop
+  end
 end

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -57,7 +57,6 @@ class TestStackTable < Minitest::Test
   end
 
   def test_calling_to_h_multiple_times
-    return skip("TODO")
     stack_table = Vernier::StackTable.new
     stack_table.current_stack
 
@@ -118,6 +117,7 @@ class TestStackTable < Minitest::Test
     collector.start
 
     stack_table = collector.stack_table
+    stack_table.current_stack
     100_000.times do |i|
       eval("stack_table.current_stack", binding, "(eval)", i)
     end

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -55,6 +55,16 @@ class TestStackTable < Minitest::Test
     #assert_equal func1, func3
   end
 
+  def test_calling_to_h_multiple_times
+    return skip("TODO")
+    stack_table = Vernier::StackTable.new
+    stack_table.current_stack
+
+    first = stack_table.to_h
+    second = stack_table.to_h
+    assert_equal first, second
+  end
+
   def test_current_sample_with_offset
     stack_table = Vernier::StackTable.new
 

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -79,6 +79,18 @@ class TestStackTable < Minitest::Test
     end
   end
 
+  def test_does_not_allocate
+    stack_table = Vernier::StackTable.new
+
+    before = GC.stat(:total_allocated_objects)
+    10000.times do
+      stack_table.current_stack
+    end
+    after = GC.stat(:total_allocated_objects)
+
+    assert after < before + 10
+  end
+
   def test_collector_stack_table
     collector = Vernier::Collector.new(:custom)
     collector.start

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestStackTable < Minitest::Test
+  def test_new
+    Vernier::StackTable.new
+  end
+
+  def test_empty_to_h
+    stack_table = Vernier::StackTable.new
+    hash = stack_table.to_h
+    assert_empty hash[:stack_table][:parent]
+    assert_empty hash[:stack_table][:frame]
+    assert_empty hash[:frame_table][:func]
+    assert_empty hash[:frame_table][:line]
+    assert_empty hash[:func_table][:name]
+    assert_empty hash[:func_table][:filename]
+    assert_empty hash[:func_table][:first_line]
+  end
+
+  def test_current_sample
+    stack_table = Vernier::StackTable.new
+    stack1 = stack_table.current_stack; stack2 = stack_table.current_stack
+    stack3 = stack_table.current_stack
+
+    assert_equal stack1, stack2
+    refute_equal stack1, stack3
+
+    hash = stack_table.to_h
+
+    # We must have recorded at least one stack for each level of depth of our
+    # current stack
+    stack_size = caller_locations.size
+    assert_operator hash[:stack_table][:parent].size, :>, caller_locations.size+1
+
+    frame1 = hash[:stack_table][:frame][stack1]
+    frame3 = hash[:stack_table][:frame][stack3]
+
+    func1 = hash[:frame_table][:func][frame1]
+    func3 = hash[:frame_table][:func][frame1]
+
+    name1 = hash[:func_table][:name][func1]
+    name3 = hash[:func_table][:name][func3]
+    assert_equal "#{self.class}##{__method__}", name1
+    assert_equal "#{self.class}##{__method__}", name3
+
+    filename1 = hash[:func_table][:filename][func1]
+    filename3 = hash[:func_table][:filename][func3]
+    assert_equal File.absolute_path(__FILE__), File.expand_path(filename1)
+    assert_equal File.absolute_path(__FILE__), File.expand_path(filename3)
+
+    # Frames should not be the same, different lines
+    refute_equal frame1, frame3
+
+    #assert_equal func1, func3
+  end
+end

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -31,7 +31,6 @@ class TestStackTable < Minitest::Test
 
     # We must have recorded at least one stack for each level of depth of our
     # current stack
-    stack_size = caller_locations.size
     assert_operator hash[:stack_table][:parent].size, :>, caller_locations.size+1
 
     frame1 = hash[:stack_table][:frame][stack1]
@@ -54,5 +53,16 @@ class TestStackTable < Minitest::Test
     refute_equal frame1, frame3
 
     #assert_equal func1, func3
+  end
+
+  def test_collector_stack_table
+    collector = Vernier::Collector.new(:custom)
+    collector.start
+    collector.sample
+    collector.stop
+
+    assert_kind_of Vernier::StackTable, collector.stack_table
+
+    assert_operator collector.stack_table.to_h[:stack_table][:parent].size, :>, caller_locations.size+1
   end
 end

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -52,7 +52,8 @@ class TestStackTable < Minitest::Test
     # Frames should not be the same, different lines
     refute_equal frame1, frame3
 
-    #assert_equal func1, func3
+    assert_equal func1, func3
+    assert_equal hash[:func_table][:name].uniq, hash[:func_table][:name]
   end
 
   def test_calling_to_h_multiple_times

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -146,6 +146,8 @@ class TestStackTable < Minitest::Test
     actual.reverse_each do |line|
       if line.start_with?("<cfunc>:0")
         line.gsub!(/\A<cfunc>:0/, prev)
+      elsif line.start_with?("<internal:")
+        line.gsub!(/\A<internal:[^>]*>/, "")
       else
         prev = line[/\A(.*):in '/, 1]
       end

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -55,6 +55,30 @@ class TestStackTable < Minitest::Test
     #assert_equal func1, func3
   end
 
+  def test_current_sample_with_offset
+    stack_table = Vernier::StackTable.new
+
+    # No offset specified
+    stack1 = stack_table.current_stack
+    stack2 = stack_table.current_stack
+    refute_equal stack1, stack2
+
+    # Offset 0 - this method, different lines
+    stack1 = stack_table.current_stack(0)
+    stack2 = stack_table.current_stack(0)
+    refute_equal stack1, stack2
+
+    # Offset 1 - parent method
+    stack1 = stack_table.current_stack(1)
+    stack2 = stack_table.current_stack(1)
+    assert_equal stack1, stack2
+
+    # Too many arguments
+    assert_raises ArgumentError do
+      stack_table.current_stack(1, 2)
+    end
+  end
+
   def test_collector_stack_table
     collector = Vernier::Collector.new(:custom)
     collector.start


### PR DESCRIPTION
StackTable exposes Vernier's (previously internal) method of collecting stacks and frames without making Ruby allocations and returns a single integer representing a unique stack.

```
stack_table = Vernier::StackTable.new
stack_table.current_stack #=> 12
stack_table.current_stack #=> 13
```

This can later be decoded

```
stack_table.backtrace(12)
#=> ["test.rb:5:in 'foo'",
#    "test.rb:9:in 'bar'"]
```

The first use of this can be collecting stack indexes which are compatible with the output of Vernier's collectors (ex. to add them to markers). The second is performance.

This is 2-3x faster than using `caller_locations`, however the biggest gains would be when additional processing is done on the stack in Ruby (ex. filtering or reformatting) which can be avoided because stacks and frames are de-duplicated.

```
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
Warming up --------------------------------------
              caller    28.485k i/100ms
    caller_locations   110.542k i/100ms
stack_table.current_stack
                       303.853k i/100ms
Calculating -------------------------------------
              caller    283.979k (± 0.3%) i/s -      1.424M in   5.015382s
    caller_locations      1.128M (± 0.2%) i/s -      5.748M in   5.094051s
stack_table.current_stack
                          3.064M (± 0.2%) i/s -     15.497M in   5.057551s
```