### PR TITLE
Make `trace_retained` API consistent with `profile`

### DIFF
--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -56,8 +56,8 @@ module Vernier
     result
   end
 
-  def self.trace_retained(out: nil, gc: true, &block)
-    profile(mode: :retained, out:, gc:, &block)
+  def self.trace_retained(**profile_options, &block)
+    profile(**profile_options.merge(mode: :retained), &block)
   end
 
   class Collector


### PR DESCRIPTION
Mostly a cosmetic change. #61 moved the options to the collector itself, a benefit of that is not having to update all the profile method APIs every time a new option is added.

This ensures `trace_contained` is consistent with the rest of these methods.