### PR TITLE
Add support for FreeBSD

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -14,9 +14,13 @@
 
 #include <sys/time.h>
 #include <signal.h>
-#ifdef __APPLE__
+#if defined(__APPLE__)
 /* macOS */
 #include <dispatch/dispatch.h>
+#elif defined(__FreeBSD__)
+/* FreeBSD */
+#include <pthread_np.h>
+#include <semaphore.h>
 #else
 /* Linux */
 #include <semaphore.h>
@@ -786,11 +790,13 @@ class SampleTranslator {
 
 typedef uint64_t native_thread_id_t;
 static native_thread_id_t get_native_thread_id() {
-#ifdef __APPLE__
+#if defined(__APPLE__)
     uint64_t thread_id;
     int e = pthread_threadid_np(pthread_self(), &thread_id);
     if (e != 0) rb_syserr_fail(e, "pthread_threadid_np");
     return thread_id;
+#elif defined(__FreeBSD__)
+    return pthread_getthreadid_np();
 #else
     // gettid() is only available as of glibc 2.30
     pid_t tid = syscall(SYS_gettid);


### PR DESCRIPTION
In order to get the current thread id on FreeBSD, we can use the non-portable `pthread_getthreadid_np()` function.

Test suite pass:

```sh-session
romain@zappy ~/Projects/vernier % bundle exec rake                                                                                             
mkdir -p tmp/amd64-freebsd14/vernier/3.2.3
cd tmp/amd64-freebsd14/vernier/3.2.3
/usr/local/bin/ruby32 -I. ../../../../ext/vernier/extconf.rb
checking for ruby/thread.h... yes
checking for rb_internal_thread_event_data_t.thread in ruby/thread.h... no
checking for rb_profile_thread_frames() in ruby/debug.h... no
checking for pthread_setname_np()... yes
creating Makefile
cd -
cd tmp/amd64-freebsd14/vernier/3.2.3
/usr/local/bin/gmake
compiling ../../../../ext/vernier/vernier.cc
linking shared-object vernier/vernier.so
cd -
mkdir -p tmp/amd64-freebsd14/stage/lib/vernier
/usr/local/bin/gmake install sitearchdir=../../../../lib/vernier sitelibdir=../../../../lib/vernier target_prefix=
/usr/bin/install -c -m 0755 vernier.so ../../../../lib/vernier
cp tmp/amd64-freebsd14/vernier/3.2.3/vernier.so tmp/amd64-freebsd14/stage/lib/vernier/vernier.so
Run options: --seed 35046

# Running:

............................................S.......

Finished in 4.508479s, 11.5338 runs/s, 2226.6935 assertions/s.

52 runs, 10039 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
romain@zappy ~/Projects/vernier % 
```
