### PR TITLE
Minify stack tables per-thread in firefox output

### DIFF
--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -75,7 +75,7 @@ module Vernier
     def stop
       result = finish
 
-      result.instance_variable_set("@stack_table", stack_table.to_h)
+      result.stack_table = stack_table
       @thread_names.finish
 
       @hooks.each do |hook|

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -219,17 +219,21 @@ module Vernier
           end
           @is_main = true if profile.threads.size == 1
 
+          @stack_table = profile._stack_table
+          @samples = samples # FIXME
+          @stack_table_hash = @stack_table.to_h
+
           timestamps ||= [0] * samples.size
-          @samples, @weights, @timestamps = samples, weights, timestamps
+          @weights, @timestamps = weights, timestamps
           @sample_categories = sample_categories || ([0] * samples.size)
           @markers = markers
 
           @started_at, @stopped_at = started_at, stopped_at
 
-          names = profile.func_table.fetch(:name)
-          filenames = profile.func_table.fetch(:filename)
+          names = @stack_table_hash[:func_table].fetch(:name)
+          filenames = @stack_table_hash[:func_table].fetch(:filename)
 
-          stacks_size = profile.stack_table.fetch(:frame).size
+          stacks_size = @stack_table.stack_count
           @categorized_stacks = Hash.new do |h, k|
             h[k] = h.size + stacks_size
           end
@@ -253,7 +257,7 @@ module Vernier
               nil
             end
           end
-          @frame_implementations = profile.frame_table.fetch(:func).map do |func_idx|
+          @frame_implementations = @stack_table_hash[:frame_table].fetch(:func).map do |func_idx|
             func_implementations[func_idx]
           end
 
@@ -267,10 +271,10 @@ module Vernier
 
             (ruby_category.subcategories.detect {|c| c.matches?(filename) } || ruby_category.subcategories.first).idx
           end
-          @frame_categories = profile.frame_table.fetch(:func).map do |func_idx|
+          @frame_categories = @stack_table_hash[:frame_table].fetch(:func).map do |func_idx|
             func_categories[func_idx]
           end
-          @frame_subcategories = profile.frame_table.fetch(:func).map do |func_idx|
+          @frame_subcategories = @stack_table_hash[:frame_table].fetch(:func).map do |func_idx|
             func_subcategories[func_idx]
           end
         end
@@ -425,8 +429,8 @@ module Vernier
         end
 
         def stack_table
-          frames = profile.stack_table.fetch(:frame).dup
-          prefixes = profile.stack_table.fetch(:parent).dup
+          frames =   @stack_table_hash[:stack_table].fetch(:frame).dup
+          prefixes = @stack_table_hash[:stack_table].fetch(:parent).dup
           categories  = frames.map{|idx| @frame_categories[idx].idx }
           subcategories  = frames.map{|idx| @frame_subcategories[idx] }
 
@@ -450,8 +454,8 @@ module Vernier
         end
 
         def frame_table
-          funcs = profile.frame_table.fetch(:func)
-          lines = profile.frame_table.fetch(:line)
+          funcs = @stack_table_hash[:frame_table].fetch(:func)
+          lines = @stack_table_hash[:frame_table].fetch(:line)
           size = funcs.length
           none = [nil] * size
           categories = @frame_categories.map(&:idx)
@@ -478,7 +482,7 @@ module Vernier
 
           cfunc_idx = @strings["<cfunc>"]
           is_js = @filenames.map { |fn| fn != cfunc_idx }
-          line_numbers = profile.func_table.fetch(:first_line).map.with_index do |line, i|
+          line_numbers = @stack_table_hash[:func_table].fetch(:first_line).map.with_index do |line, i|
             if is_js[i] || line != 0
               line
             else

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -219,8 +219,10 @@ module Vernier
           end
           @is_main = true if profile.threads.size == 1
 
-          @stack_table = profile._stack_table
-          @samples = samples # FIXME
+          @stack_table = Vernier::StackTable.new
+          samples = samples.map { |sample| @stack_table.convert(profile._stack_table, sample) }
+
+          @samples = samples
           @stack_table_hash = @stack_table.to_h
 
           timestamps ||= [0] * samples.size

--- a/lib/vernier/result.rb
+++ b/lib/vernier/result.rb
@@ -1,15 +1,11 @@
 module Vernier
   class Result
-    def stack_table
-      @stack_table[:stack_table]
+    def stack_table=(stack_table)
+      @stack_table = stack_table
     end
 
-    def frame_table
-      @stack_table[:frame_table]
-    end
-
-    def func_table
-      @stack_table[:func_table]
+    def _stack_table
+      @stack_table
     end
 
     attr_reader :markers
@@ -81,12 +77,12 @@ module Vernier
 
     class Func < BaseType
       def label
-        result.func_table[:name][idx]
+        result._stack_table.func_name(idx)
       end
       alias name label
 
       def filename
-        result.func_table[:filename][idx]
+        result._stack_table.func_filename(idx)
       end
 
       def to_s
@@ -100,12 +96,12 @@ module Vernier
       alias name label
 
       def func
-        func_idx = result.frame_table[:func][idx]
+        func_idx = result._stack_table.frame_func_idx(idx)
         Func.new(result, func_idx)
       end
 
       def line
-        result.frame_table[:line][idx]
+        result.frame_line_idx(idx)
       end
 
       def to_s
@@ -119,14 +115,14 @@ module Vernier
 
         stack_idx = idx
         while stack_idx
-          frame_idx = result.stack_table[:frame][stack_idx]
+          frame_idx = result._stack_table.stack_frame_idx(stack_idx)
           yield Frame.new(result, frame_idx)
-          stack_idx = result.stack_table[:parent][stack_idx]
+          stack_idx = result._stack_table.stack_parent_idx(stack_idx)
         end
       end
 
       def leaf_frame_idx
-        result.stack_table[:frame][idx]
+        result._stack_table.stack_frame_idx(idx)
       end
 
       def leaf_frame

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,28 +12,11 @@ class Minitest::Test
   def assert_valid_result(result)
     assert_equal result.samples.length, result.weights.length
 
-    stack_table_size = result.stack_table[:parent].length
-    assert_equal stack_table_size, result.stack_table[:frame].length
+    stack_table_size = result._stack_table.stack_count
 
     result.samples.each do |stack_idx|
       assert_kind_of Integer, stack_idx
       assert stack_idx < stack_table_size
-    end
-
-    frame_table_size = result.frame_table[:func].length
-    assert_equal frame_table_size, result.frame_table[:line].length
-    result.stack_table[:frame].each do |frame_idx|
-      assert frame_idx < frame_table_size, "frame index (#{frame_idx}) out of range #{frame_table_size}"
-    end
-
-    func_table_size = result.func_table[:name].length
-    assert_equal func_table_size, result.func_table[:first_line].length
-    assert_equal func_table_size, result.func_table[:filename].length
-    result.frame_table[:func].each do |func_idx|
-      assert func_idx < func_table_size
-    end
-
-    result.func_table[:name].each do |name|
     end
   end
 end

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -125,6 +125,25 @@ class TestStackTable < Minitest::Test
     collector.stop
   end
 
+  def test_convert
+    original = Vernier::StackTable.new
+    samples = []
+    1000.times do |i|
+      samples << eval("original.current_stack", binding, "(eval)", i)
+    end
+    assert original.stack_count > 1000
+
+    original_sample = samples[50]
+    reduced = Vernier::StackTable.new
+    new_sample = reduced.convert(original, original_sample)
+
+    assert reduced.stack_count < 100
+
+    expected = original.backtrace(original_sample)
+    actual = reduced.backtrace(new_sample)
+    assert_equal expected, actual
+  end
+
   def test_backtrace
     stack_table = Vernier::StackTable.new
     expected = caller_locations(0); index = stack_table.current_stack


### PR DESCRIPTION
Previously we serialized the stack tables exactly the same way for each thread, which for threads with few unique stacks ended up being very wasteful.

In some cases this might make the gzip less effective, but should make writing the output faster and the uncompressed JSON _much_ smaller.