### PR TITLE
Middleware: access Rack GET params as strings not symbols

### DIFF
--- a/lib/vernier/middleware.rb
+++ b/lib/vernier/middleware.rb
@@ -12,8 +12,8 @@ module Vernier
       permitted = @permit.call(request)
       return @app.call(env) unless permitted
 
-      interval = request.GET.fetch(:vernier_interval, 200).to_i
-      allocation_sample_rate = request.GET.fetch(:vernier_allocation_sample_rate, 200).to_i
+      interval = request.GET.fetch("vernier_interval", 200).to_i
+      allocation_sample_rate = request.GET.fetch("vernier_allocation_sample_rate", 200).to_i
 
       result = Vernier.trace(interval:, allocation_sample_rate:, hooks: [:rails]) do
         @app.call(env)


### PR DESCRIPTION
While integrating this into an app, I noticed these are accessed as symbols, which I'm pretty sure won't work.

A few lines up from the diff in this PR, the `request.GET.has_key?("vernier")` is accessed as a string, so I'm pretty sure this is the right way to do it.
