### PR TITLE
Show all threads and pre-select profile start thread by default

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1202,6 +1202,10 @@ class Thread {
             return rb_thread_main() == ruby_thread;
         }
 
+        bool is_start(VALUE start_thread) {
+            return start_thread == ruby_thread;
+        }
+
         bool running() {
             return state != State::STOPPED;
         }
@@ -1309,6 +1313,7 @@ class BaseCollector {
     StackTable *stack_table;
     VALUE stack_table_value;
 
+    VALUE start_thread;
     TimeStamp started_at;
 
     BaseCollector(VALUE stack_table_value) : stack_table_value(stack_table_value), stack_table(get_stack_table(stack_table_value)) {
@@ -1320,6 +1325,7 @@ class BaseCollector {
             return false;
         }
 
+        start_thread = rb_thread_current();
         started_at = TimeStamp::Now();
 
         running = true;
@@ -1938,6 +1944,7 @@ class TimeCollector : public BaseCollector {
                 rb_hash_aset(hash, sym("stopped_at"), ULL2NUM(thread->stopped_at.nanoseconds()));
             }
             rb_hash_aset(hash, sym("is_main"), thread->is_main() ? Qtrue : Qfalse);
+            rb_hash_aset(hash, sym("is_start"), thread->is_start(BaseCollector::start_thread) ? Qtrue : Qfalse);
 
         }
 

--- a/test/firefox_test_helpers.rb
+++ b/test/firefox_test_helpers.rb
@@ -14,6 +14,8 @@ module FirefoxTestHelpers
     threads = data["threads"]
     assert_equal 1, threads.count { _1["isMainThread"] }
     assert_operator threads.size, :>=, 1
+    assert_equal threads.size, meta["initialVisibleThreads"].size
+    assert_equal 1, meta["initialSelectedThreads"].size
     threads.each do |thread|
       assert thread["name"]
       assert thread["pid"]


### PR DESCRIPTION
Closes https://github.com/jhawthorn/vernier/issues/56
Related to https://github.com/jhawthorn/vernier/pull/75

Ensures that on profile load, no threads are filtered out i.e. [`initialVisibleThreads`](https://github.com/firefox-devtools/profiler/blob/245b1a400c5c368ccc13641d0335398bafa0e870/src/types/profile.js#L909-L912) contains all threads, and that the thread in which the profiler was started is the pre-selected thread i.e. it's the one and only thread in [`initialSelectedThreads`](https://github.com/firefox-devtools/profiler/blob/245b1a400c5c368ccc13641d0335398bafa0e870/src/types/profile.js#L913-L916).

<details>
<summary>Manual testing</summary>

```ruby
# main thread start

Vernier.profile(out: "output_main.json") do
  10.times.map do |i|
    Thread.new do
      Thread.current.name = "Spawned #{i}"
      sleep 0.01
    end
  end.each(&:join)
end

# spawned thread start

10.times.map do |i|
  Thread.new do
    if i == 5
      Vernier.profile(out: "output_spawned.json") do
        Thread.current.name = "Spawned #{i}"
        sleep 0.01
      end
    else
      Thread.current.name = "Spawned #{i}"
      sleep 0.01
    end
  end
end.each(&:join)
```

[output_main.json](https://github.com/user-attachments/files/16038921/output_main.json)
[output_spawned.json](https://github.com/user-attachments/files/16038923/output_spawned.json)

</details>