### PR TITLE
Fix output of `vernier --version`

### DIFF
--- a/exe/vernier
+++ b/exe/vernier
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require "optparse"
+require "vernier/version"
 
 banner = <<-END
 Usage: vernier run [FLAGS] -- COMMAND
@@ -10,6 +11,8 @@ END
 
 options = {}
 parser = OptionParser.new(banner) do |o|
+  o.version = Vernier::VERSION
+
   o.on('--output [FILENAME]', String, "output filename") do |s|
     options[:output] = s
   end


### PR DESCRIPTION
Previous output:
```
$ vernier -v
vernier: version unknown
```

Optparser generates a version swtich by default, even if it doesn't appear in the help output. Tested by building and installing the gem locally.