### PR TITLE
Avoid recording -1 sentinel in profile

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -672,10 +672,6 @@ StackTable::stack_table_convert(VALUE self, VALUE original_tableval, VALUE origi
     StackTable *original_table = get_stack_table(original_tableval);
     int original_idx = NUM2INT(original_idxval);
 
-    if (original_idx == -1) {
-        return original_idxval;
-    }
-
     int original_size;
     {
         const std::lock_guard<std::mutex> lock(original_table->stack_mutex);

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1027,13 +1027,15 @@ class SampleList {
         }
 
         void record_sample(int stack_index, TimeStamp time, Category category) {
-            if (
-                    !empty() &&
-                    stacks.back() == stack_index &&
-                    categories.back() == category)
-            {
-                // We don't compare timestamps for de-duplication
-                weights.back() += 1;
+          // FIXME: probably better to avoid generating -1 higher up.
+          // Currently this happens when we measure an empty stack. Ideally we would have a better representation
+          if (stack_index < 0)
+            return;
+
+          if (!empty() && stacks.back() == stack_index &&
+              categories.back() == category) {
+            // We don't compare timestamps for de-duplication
+            weights.back() += 1;
             } else {
                 stacks.push_back(stack_index);
                 timestamps.push_back(time);

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "vernier"
 require "gvltest"
+require "firefox_test_helpers"
 
 ENV["MT_CPU"] = "0"
 require "minitest/autorun"
@@ -17,7 +18,8 @@ class Minitest::Test
 
     result.samples.each do |stack_idx|
       assert_kind_of Integer, stack_idx
-      assert stack_idx < stack_table_size
+      assert_operator stack_idx, :<, stack_table_size
+      assert_operator stack_idx, :>=, 0
     end
   end
 end

--- a/test/test_time_collector.rb
+++ b/test/test_time_collector.rb
@@ -224,6 +224,16 @@ class TestTimeCollector < Minitest::Test
     assert_equal expected, thread_names
   end
 
+  def test_process_detach
+    result = Vernier.trace do
+      pid = Process.spawn("sleep", "0.01")
+      wait_thr = Process.detach(pid)
+      wait_thr.join
+    end
+    assert_valid_result result
+    assert_operator result.threads.count, :>=, 2
+  end
+
   def test_start_stop
     Vernier.start_profile(interval: SAMPLE_SCALE_INTERVAL)
     two_slow_methods


### PR DESCRIPTION
Fixes https://github.com/jhawthorn/vernier/issues/85

This works around a bug where we get an empty stack on suspend. In the future we should better support having an empty stack.

This fixes an issue where we would record a `-1` sample and then when creating the firefox-compatible output would end up with a null in the frame list and make the resulting file error on load.