### PR TITLE
Rename `allocation_sample_rate` to `allocation_interval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Option | Description
 `mode` | The sampling mode to use. One of `:wall`, `:retained` or `:custom`. Default is `:wall`.
 `out` | The file to write the profile to.
 `interval` | The sampling interval in microseconds. Default is `500`. Only available in `:wall` mode.
-`allocation_sample_rate` | The allocation sampling interval in number of allocations. Default is `0` (disabled). Only available in `:wall` mode.
+`allocation_interval` | The allocation sampling interval in number of allocations. Default is `0` (disabled). Only available in `:wall` mode.
 `gc` | Initiate a full and immediate garbage collection cycle before profiling. Default is `true`. Only available in `:retained` mode.
 
 ## Development

--- a/examples/measure_overhead.rb
+++ b/examples/measure_overhead.rb
@@ -30,10 +30,10 @@ compare do
   end
 end
 
-compare(allocation_sample_rate: 1000) do
+compare(allocation_interval: 1000) do
   Object.new
 end
 
-compare(allocation_sample_rate: 1) do
+compare(allocation_interval: 1) do
   Object.new
 end

--- a/examples/rails.rb
+++ b/examples/rails.rb
@@ -123,7 +123,7 @@ end
 # warm up
 make_request.call
 
-Vernier.trace(out: "rails.json", hooks: [:rails], allocation_sample_rate: 100) do |collector|
+Vernier.trace(out: "rails.json", hooks: [:rails], allocation_interval: 100) do |collector|
   1000.times do
     make_request.call
   end

--- a/examples/threaded_http_requests.rb
+++ b/examples/threaded_http_requests.rb
@@ -1,6 +1,6 @@
 require "vernier"
 
-Vernier.trace(out: "http_requests.json", allocation_sample_rate: 100) do
+Vernier.trace(out: "http_requests.json", allocation_interval: 100) do
 
 require "net/http"
 require "uri"

--- a/exe/vernier
+++ b/exe/vernier
@@ -21,8 +21,8 @@ FLAGS:
         o.on('--interval [MICROSECONDS]', Integer, "sampling interval (default 500)") do |i|
           options[:interval] = i
         end
-        o.on('--allocation_sample_rate [ALLOCATIONS]', Integer, "allocation sampling interval (default 0 disabled)") do |i|
-          options[:allocation_sample_rate] = i
+        o.on('--allocation-interval [ALLOCATIONS]', Integer, "allocation sampling interval (default 0 disabled)") do |i|
+          options[:allocation_interval] = i
         end
         o.on('--signal [NAME]', String, "specify a signal to start and stop the profiler") do |s|
           options[:signal] = s
@@ -30,7 +30,7 @@ FLAGS:
         o.on('--start-paused', "don't automatically start the profiler") do
           options[:start_paused] = true
         end
-        o.on('--hooks [HOOKS]', String, "Enable instrumentation hooks. Currently supported: rails") do |s|
+        o.on('--hooks [HOOKS]', String, "enable instrumentation hooks, currently supported: rails") do |s|
           options[:hooks] = s
         end
       end

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1337,7 +1337,7 @@ class BaseCollector {
     virtual void write_meta(VALUE meta, VALUE result) {
         rb_hash_aset(meta, sym("started_at"), ULL2NUM(started_at.nanoseconds()));
         rb_hash_aset(meta, sym("interval"), Qnil);
-        rb_hash_aset(meta, sym("allocation_sample_rate"), Qnil);
+        rb_hash_aset(meta, sym("allocation_interval"), Qnil);
 
     }
 
@@ -1627,8 +1627,8 @@ class TimeCollector : public BaseCollector {
     SignalSafeSemaphore thread_stopped;
 
     TimeStamp interval;
-    unsigned int allocation_sample_rate;
-    unsigned int allocation_sample_tick = 0;
+    unsigned int allocation_interval;
+    unsigned int allocation_tick = 0;
 
     VALUE tp_newobj = Qnil;
 
@@ -1641,14 +1641,14 @@ class TimeCollector : public BaseCollector {
     }
 
     public:
-    TimeCollector(VALUE stack_table, TimeStamp interval, unsigned int allocation_sample_rate) : BaseCollector(stack_table), interval(interval), allocation_sample_rate(allocation_sample_rate), threads(*get_stack_table(stack_table)) {
+    TimeCollector(VALUE stack_table, TimeStamp interval, unsigned int allocation_interval) : BaseCollector(stack_table), interval(interval), allocation_interval(allocation_interval), threads(*get_stack_table(stack_table)) {
     }
 
     void record_newobj(VALUE obj) {
-        if (++allocation_sample_tick < allocation_sample_rate) {
+        if (++allocation_tick < allocation_interval) {
             return;
         }
-        allocation_sample_tick = 0;
+        allocation_tick = 0;
 
         VALUE current_thread = rb_thread_current();
         threads.mutex.lock();
@@ -1666,7 +1666,7 @@ class TimeCollector : public BaseCollector {
     void write_meta(VALUE meta, VALUE result) {
         BaseCollector::write_meta(meta, result);
         rb_hash_aset(meta, sym("interval"), ULL2NUM(interval.microseconds()));
-        rb_hash_aset(meta, sym("allocation_sample_rate"), ULL2NUM(allocation_sample_rate));
+        rb_hash_aset(meta, sym("allocation_interval"), ULL2NUM(allocation_interval));
 
     }
 
@@ -1864,7 +1864,7 @@ class TimeCollector : public BaseCollector {
             this->threads.initial(thread);
         }
 
-        if (allocation_sample_rate > 0) {
+        if (allocation_interval > 0) {
             tp_newobj = rb_tracepoint_new(0, RUBY_INTERNAL_EVENT_NEWOBJ, newobj_i, this);
             rb_tracepoint_enable(tp_newobj);
         }
@@ -2042,14 +2042,14 @@ static VALUE collector_new(VALUE self, VALUE mode, VALUE options) {
             interval = TimeStamp::from_microseconds(NUM2UINT(intervalv));
         }
 
-        VALUE allocation_sample_ratev = rb_hash_aref(options, sym("allocation_sample_rate"));
-        unsigned int allocation_sample_rate;
-        if (NIL_P(allocation_sample_ratev)) {
-            allocation_sample_rate = 0;
+        VALUE allocation_intervalv = rb_hash_aref(options, sym("allocation_interval"));
+        unsigned int allocation_interval;
+        if (NIL_P(allocation_intervalv)) {
+            allocation_interval = 0;
         } else {
-            allocation_sample_rate = NUM2UINT(allocation_sample_ratev);
+            allocation_interval = NUM2UINT(allocation_intervalv);
         }
-        collector = new TimeCollector(stack_table, interval, allocation_sample_rate);
+        collector = new TimeCollector(stack_table, interval, allocation_interval);
     } else {
         rb_raise(rb_eArgError, "invalid mode");
     }

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -2043,6 +2043,9 @@ static VALUE collector_new(VALUE self, VALUE mode, VALUE options) {
         }
 
         VALUE allocation_intervalv = rb_hash_aref(options, sym("allocation_interval"));
+        if (NIL_P(allocation_intervalv))
+            allocation_intervalv = rb_hash_aref(options, sym("allocation_sample_rate"));
+
         unsigned int allocation_interval;
         if (NIL_P(allocation_intervalv)) {
             allocation_interval = 0;

--- a/lib/vernier/autorun.rb
+++ b/lib/vernier/autorun.rb
@@ -17,12 +17,12 @@ module Vernier
 
     def self.start
       interval = options.fetch(:interval, 500).to_i
-      allocation_sample_rate = options.fetch(:allocation_sample_rate, 0).to_i
+      allocation_interval = options.fetch(:allocation_interval, 0).to_i
       hooks = options.fetch(:hooks, "").split(",")
 
       STDERR.puts("starting profiler with interval #{interval}")
 
-      @collector = Vernier::Collector.new(:wall, interval:, allocation_sample_rate:, hooks:)
+      @collector = Vernier::Collector.new(:wall, interval:, allocation_interval:, hooks:)
       @collector.start
     end
 

--- a/lib/vernier/middleware.rb
+++ b/lib/vernier/middleware.rb
@@ -13,9 +13,9 @@ module Vernier
       return @app.call(env) unless permitted
 
       interval = request.GET.fetch("vernier_interval", 200).to_i
-      allocation_sample_rate = request.GET.fetch("vernier_allocation_sample_rate", 200).to_i
+      allocation_interval = request.GET.fetch("vernier_allocation_interval", 200).to_i
 
-      result = Vernier.trace(interval:, allocation_sample_rate:, hooks: [:rails]) do
+      result = Vernier.trace(interval:, allocation_interval:, hooks: [:rails]) do
         @app.call(env)
       end
       body = result.to_gecko(gzip: true)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -8,7 +8,7 @@ class IntegrationTest < Minitest::Test
   LIB_DIR = File.expand_path("../lib", __dir__)
 
   def test_allocations
-    result = run_vernier({allocation_sample_rate: 1}, "-e", "")
+    result = run_vernier({allocation_interval: 1}, "-e", "")
     assert_valid_firefox_profile(result)
   end
 

--- a/test/output/test_firefox.rb
+++ b/test/output/test_firefox.rb
@@ -223,7 +223,7 @@ class TestOutputFirefox < Minitest::Test
   end
 
   def test_allocation_samples
-    result = Vernier.trace(allocation_sample_rate: 1) do
+    result = Vernier.trace(allocation_interval: 1) do
       JSON.parse(%{{ "foo": { "bar": ["baz", 123] } }})
     end
 

--- a/test/test_allocations.rb
+++ b/test/test_allocations.rb
@@ -16,8 +16,23 @@ class TestAllocations < Minitest::Test
     assert_includes 100..102, stacks.tally.values.max
   end
 
-  def test_sample_rate
+  def test_interval
     result = Vernier.trace(allocation_interval: 10) do
+      1000.times do
+        Object.new
+      end
+    end
+
+    assert_valid_result result
+
+    allocations = result.main_thread.fetch(:allocations)
+    stacks = allocations.fetch(:samples)
+
+    assert_includes 100..102, stacks.tally.values.max
+  end
+
+  def test_sample_rate
+    result = Vernier.trace(allocation_sample_rate: 10) do
       1000.times do
         Object.new
       end

--- a/test/test_allocations.rb
+++ b/test/test_allocations.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class TestAllocations < Minitest::Test
   def test_plain_objects
-    result = Vernier.trace(allocation_sample_rate: 1) do
+    result = Vernier.trace(allocation_interval: 1) do
       100.times do
         Object.new
       end
@@ -17,7 +17,7 @@ class TestAllocations < Minitest::Test
   end
 
   def test_sample_rate
-    result = Vernier.trace(allocation_sample_rate: 10) do
+    result = Vernier.trace(allocation_interval: 10) do
       1000.times do
         Object.new
       end
@@ -32,7 +32,7 @@ class TestAllocations < Minitest::Test
   end
 
   def test_thread_allocation
-    result = Vernier.trace(allocation_sample_rate: 1) do
+    result = Vernier.trace(allocation_interval: 1) do
       Thread.new do
         100.times do
           Object.new

--- a/test/test_retained_memory.rb
+++ b/test/test_retained_memory.rb
@@ -158,7 +158,7 @@ class TestRetainedMemory < Minitest::Test
     assert_equal :retained, result.meta[:mode]
     assert_equal output_file, result.meta[:out]
     assert_nil result.meta[:interval]
-    assert_nil result.meta[:allocation_sample_rate]
+    assert_nil result.meta[:allocation_interval]
     assert_equal true, result.meta[:gc]
   end
 

--- a/test/test_time_collector.rb
+++ b/test/test_time_collector.rb
@@ -262,13 +262,13 @@ class TestTimeCollector < Minitest::Test
     result = Vernier.profile(
       out: output_file,
       interval: SAMPLE_SCALE_INTERVAL,
-      allocation_sample_rate: SAMPLE_SCALE_ALLOCATIONS
+      allocation_interval: SAMPLE_SCALE_ALLOCATIONS
     ) { }
 
     assert_equal :wall, result.meta[:mode]
     assert_equal output_file, result.meta[:out]
     assert_equal SAMPLE_SCALE_INTERVAL, result.meta[:interval]
-    assert_equal SAMPLE_SCALE_ALLOCATIONS, result.meta[:allocation_sample_rate]
+    assert_equal SAMPLE_SCALE_ALLOCATIONS, result.meta[:allocation_interval]
     assert_equal false, result.meta[:gc]
   end
 


### PR DESCRIPTION
Closes https://github.com/jhawthorn/vernier/issues/91

Renames the CLI flag from `--allocation_sample_rate` to `--allocation-interval` (hyphen for consistency with `--start-paused`, also pretty standard).

Renames the option kwarg from `allocation_sample_rate` to `allocation_interval`. Also renamed vars to match.