### PR TITLE
Order GC marker labels

### DIFF
--- a/lib/vernier/marker.rb
+++ b/lib/vernier/marker.rb
@@ -12,19 +12,19 @@ module Vernier
 
     MARKER_STRINGS = []
 
-    MARKER_STRINGS[Type::GVL_THREAD_STARTED] = "Thread started"
-    MARKER_STRINGS[Type::GVL_THREAD_EXITED] = "Thread exited"
+    MARKER_STRINGS[Type::GVL_THREAD_STARTED] = "\u2001Thread started"
+    MARKER_STRINGS[Type::GVL_THREAD_EXITED] = "\u2002Thread exited"
 
-    MARKER_STRINGS[Type::GC_START] = "GC start"
-    MARKER_STRINGS[Type::GC_END_MARK] = "GC end marking"
-    MARKER_STRINGS[Type::GC_END_SWEEP] = "GC end sweeping"
-    MARKER_STRINGS[Type::GC_ENTER] = "GC enter"
-    MARKER_STRINGS[Type::GC_EXIT] = "GC exit"
-    MARKER_STRINGS[Type::GC_PAUSE] = "GC pause"
+    MARKER_STRINGS[Type::GC_ENTER] = "\u2001GC enter"
+    MARKER_STRINGS[Type::GC_START] = "\u2002GC start"
+    MARKER_STRINGS[Type::GC_PAUSE] = "\u2003GC pause"
+    MARKER_STRINGS[Type::GC_END_MARK] = "\u2004GC end marking"
+    MARKER_STRINGS[Type::GC_END_SWEEP] = "\u2005GC end sweeping"
+    MARKER_STRINGS[Type::GC_EXIT] = "\u2006GC exit"
 
-    MARKER_STRINGS[Type::THREAD_RUNNING] = "Thread Running"
-    MARKER_STRINGS[Type::THREAD_STALLED] = "Thread Stalled"
-    MARKER_STRINGS[Type::THREAD_SUSPENDED] = "Thread Suspended"
+    MARKER_STRINGS[Type::THREAD_RUNNING] = "\u2001Thread Running"
+    MARKER_STRINGS[Type::THREAD_STALLED] = "\u2002Thread Stalled"
+    MARKER_STRINGS[Type::THREAD_SUSPENDED] = "\u2003Thread Suspended"
 
     MARKER_STRINGS.freeze
 

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -372,9 +372,9 @@ module Vernier
             phases << phase
 
             category =
-              if name.start_with?("GC")
+              if name.start_with?(/.GC/)
                 gc_category.idx
-              elsif name.start_with?("Thread")
+              elsif name.start_with?(/.Thread/)
                 thread_category.idx
               else
                 0

--- a/test/output/test_firefox.rb
+++ b/test/output/test_firefox.rb
@@ -57,7 +57,7 @@ class TestOutputFirefox < Minitest::Test
     names = intervals.map { |record| thread["stringArray"][record.first] }.uniq
 
     # We should have a GC pause in there
-    assert_includes names, "GC pause"
+    assert_predicate names.grep(/.GC pause/), :any?
   end
 
   def test_retained_firefox_output

--- a/test/test_time_collector.rb
+++ b/test/test_time_collector.rb
@@ -12,8 +12,8 @@ class TestTimeCollector < Minitest::Test
 
     assert_valid_result result
     # make sure we got all GC events (since we did GC.start twice)
-    assert_equal ["GC end marking", "GC end sweeping", "GC pause", "GC start"].sort,
-      result.markers.map { |x| x[1] }.grep(/^GC/).uniq.sort
+    assert_equal [" GC start", " GC pause", " GC end marking", " GC end sweeping"].sort,
+      result.markers.map { |x| x[1] }.grep(/.GC/).uniq.sort
   end
 
   def test_time_collector


### PR DESCRIPTION
Adds ~zero-width~ unicode whitespaces in sequence to the marker labels to manipulate ordering. This makes the GC state flow easier to follow.

Before | After
:-:|:-:
![Screenshot 2024-10-05 at 3 28 57 pm](https://github.com/user-attachments/assets/f6fe7e72-e068-4106-abea-0ad43ce47c30) | ![Screenshot 2024-10-05 at 5 01 49 pm](https://github.com/user-attachments/assets/e408572f-6721-4bae-abef-461a6ae18f0e)