### PR TITLE
Fix compile error on older GCC

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -2001,6 +2001,7 @@ static const rb_data_type_t rb_collector_type = {
         //.dmemsize = rb_collector_memsize,
         .dmark = collector_mark,
         .dfree = collector_free,
+        .dsize = NULL,
         .dcompact = collector_compact,
     },
 };


### PR DESCRIPTION
This was a regression in 1.3.0.

Vernier current requires a minimum of C++14: https://github.com/jhawthorn/vernier/blob/ade5d8df2056543dfd3ffb1a56e20d3d292c14f7/ext/vernier/extconf.rb#L5

Designated initialisers are only supported since C++20 - though most compilers had partial support since around C++11 as a C99 extension as long as you didn't skip any fields (i.e. if you follow the order that you would get if you omit the labels). The introduction of `.dcompact` here skipped `.dsize` and broke that restriction and thus causes a compile error on older GCC:

```
compiling vernier.cc
vernier.cc:2006:1: sorry, unimplemented: non-trivial designated initializers not supported
 };
 ^
Makefile:215: recipe for target 'vernier.o' failed
```

This was admittedly on an older Ubuntu image I'm phasing out in a few months, but I think it makes sense to fix given the minimum C++ bound in `extconf.rb` and how the fix is trivial.