### PR TITLE
Add Fiber Running / Fiber Switch events to the marker chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Gemfile.lock
 /examples/my_sleep.dylib
 .DS_Store
 .gdbinit
+/profile-*.json.gz

--- a/examples/fiber_stalls.rb
+++ b/examples/fiber_stalls.rb
@@ -1,0 +1,51 @@
+require "bundler/inline"
+gemfile do
+  source 'https://rubygems.org'
+
+  gem "async"
+end
+
+require "async"
+require "async/queue"
+
+def measure
+  x = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  yield
+  Process.clock_gettime(Process::CLOCK_MONOTONIC) - x
+end
+
+def fib(n)
+  if n < 2
+    n
+  else
+    fib(n-2) + fib(n-1)
+  end
+end
+
+# find fib that takes ~50ms
+fib_i = 50.times.find { |i| measure { fib(i) } >= 0.05 }
+sleep_i = measure { fib(fib_i) }
+
+Async {
+  latch = Async::Queue.new
+
+  workers = [
+    Async {
+      latch.pop # block until ready to measure
+
+      100.times {
+        sleep(sleep_i)
+        # stalls happen here. This worker wants to be scheduled so it can
+        # continue the loop, but will be blocked by another worker executing fib
+      }
+    },
+    Async {
+      latch.pop # block until ready to measure
+
+      100.times { fib(fib_i) }
+    },
+  ]
+
+  2.times { latch << nil }
+  workers.each(&:wait)
+}

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1033,9 +1033,13 @@ class Thread {
             }
         }
 
-        void record_fiber(VALUE fiber) {
+        void record_fiber(VALUE fiber, StackTable &frame_list) {
+            RawSample sample;
+            sample.sample();
+
+            int stack_idx = translator.translate(frame_list, sample);
             VALUE fiber_id = rb_obj_id(fiber);
-            markers->record(Marker::Type::MARKER_FIBER_SWITCH, -1, { .fiber_data = { .fiber_id = fiber_id } });
+            markers->record(Marker::Type::MARKER_FIBER_SWITCH, stack_idx, { .fiber_data = { .fiber_id = fiber_id } });
         }
 
         void set_state(State new_state) {
@@ -1607,7 +1611,7 @@ class TimeCollector : public BaseCollector {
         for (auto &threadptr : threads.list) {
             auto &thread = *threadptr;
             if (th == thread.ruby_thread) {
-                thread.record_fiber(fiber);
+                thread.record_fiber(fiber, threads.frame_list);
                 break;
             }
         }

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -784,33 +784,32 @@ class Marker {
     MarkerInfo extra_info;
 
     VALUE to_array() const {
-        VALUE record[7] = {0};
-        record[0] = Qnil; // FIXME
-        record[1] = INT2NUM(type);
-        record[2] = INT2NUM(phase);
-        record[3] = ULL2NUM(timestamp.nanoseconds());
+        VALUE record[6] = {0};
+        record[0] = INT2NUM(type);
+        record[1] = INT2NUM(phase);
+        record[2] = ULL2NUM(timestamp.nanoseconds());
 
         if (phase == Marker::Phase::INTERVAL) {
-            record[4] = ULL2NUM(finish.nanoseconds());
+            record[3] = ULL2NUM(finish.nanoseconds());
         }
         else {
-            record[4] = Qnil;
+            record[3] = Qnil;
         }
-        record[5] = stack_index == -1 ? Qnil : INT2NUM(stack_index);
+        record[4] = stack_index == -1 ? Qnil : INT2NUM(stack_index);
 
         if (type == Marker::MARKER_GC_PAUSE) {
             VALUE hash = rb_hash_new();
-            record[6] = hash;
+            record[5] = hash;
 
             rb_hash_aset(hash, sym_gc_by, extra_info.gc_data.gc_by);
             rb_hash_aset(hash, sym_state, extra_info.gc_data.gc_state);
         } else if (type == Marker::MARKER_FIBER_SWITCH) {
             VALUE hash = rb_hash_new();
-            record[6] = hash;
+            record[5] = hash;
 
             rb_hash_aset(hash, sym_fiber_id, extra_info.fiber_data.fiber_id);
         }
-        return rb_ary_new_from_values(7, record);
+        return rb_ary_new_from_values(6, record);
     }
 };
 

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -110,7 +110,7 @@ module Vernier
         original_markers = thread[:markers] || []
         original_markers += result.gc_markers || []
         original_markers.each do |data|
-          tid, type, phase, ts, te, stack, extra_info = data
+          type, phase, ts, te, stack, extra_info = data
           if type == Marker::Type::FIBER_SWITCH
             if last_fiber
               start_event = markers[last_fiber]

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -114,7 +114,7 @@ module Vernier
           if type == Marker::Type::FIBER_SWITCH
             if last_fiber
               start_event = markers[last_fiber]
-              markers << [nil, "Fiber Running", start_event[2], ts, Marker::Phase::INTERVAL, start_event[5].merge(type: "Fiber Running")]
+              markers << [nil, "Fiber Running", start_event[2], ts, Marker::Phase::INTERVAL, start_event[5].merge(type: "Fiber Running", cause: nil)]
             end
             last_fiber = markers.size
           end
@@ -128,7 +128,7 @@ module Vernier
         if last_fiber
           end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
           start_event = markers[last_fiber]
-          markers << [nil, "Fiber Running", start_event[2], end_time, Marker::Phase::INTERVAL, start_event[5].merge(type: "Fiber Running")]
+          markers << [nil, "Fiber Running", start_event[2], end_time, Marker::Phase::INTERVAL, start_event[5].merge(type: "Fiber Running", cause: nil)]
         end
 
         thread[:markers] = markers

--- a/lib/vernier/marker.rb
+++ b/lib/vernier/marker.rb
@@ -26,6 +26,8 @@ module Vernier
     MARKER_STRINGS[Type::THREAD_STALLED] = "Thread Stalled"
     MARKER_STRINGS[Type::THREAD_SUSPENDED] = "Thread Suspended"
 
+    MARKER_STRINGS[Type::FIBER_SWITCH] = "Fiber Switch"
+
     MARKER_STRINGS.freeze
 
     ##

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -104,15 +104,15 @@ module Vernier
       attr_reader :profile
 
       def data
-        markers_by_thread = profile.markers.group_by { |marker| marker[0] }
+        #markers_by_thread = profile.markers.group_by { |marker| marker[0] }
 
         threads = profile.threads.map do |ruby_thread_id, thread_info|
-          markers = markers_by_thread[ruby_thread_id] || []
+          #markers = markers_by_thread[ruby_thread_id] || []
           Thread.new(
             ruby_thread_id,
             profile,
             @categorizer,
-            markers: markers,
+            #markers: markers,
             **thread_info,
           )
         end

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -210,6 +210,18 @@ module Vernier
               { key: "gc_by", format: "string" },
             ]
           },
+          {
+            name: "FIBER_SWITCH",
+            display: [ "marker-chart", "marker-table", "timeline-overview" ],
+            tooltipLabel: "{marker.name} - {marker.data.fiber_id}",
+            data: [
+              {
+                label: "Description",
+                value: "Switch running Fiber"
+              },
+              { key: "fiber_id", format: "integer" },
+            ]
+          },
           *hook_additions
         ]
       end

--- a/lib/vernier/result.rb
+++ b/lib/vernier/result.rb
@@ -8,7 +8,7 @@ module Vernier
       @stack_table
     end
 
-    attr_reader :markers
+    attr_reader :gc_markers
 
     attr_accessor :hooks
 
@@ -25,6 +25,13 @@ module Vernier
     def weights; threads.values.flat_map { _1[:weights] }; end
     def samples; threads.values.flat_map { _1[:samples] }; end
     def sample_categories; threads.values.flat_map { _1[:sample_categories] }; end
+
+    # Legacy format. Avoid
+    def markers
+      threads&.flat_map do |tid, thread|
+        thread[:markers] || []
+      end || []
+    end
 
     # Realtime in nanoseconds since the unix epoch
     def started_at

--- a/lib/vernier/result.rb
+++ b/lib/vernier/result.rb
@@ -26,13 +26,6 @@ module Vernier
     def samples; threads.values.flat_map { _1[:samples] }; end
     def sample_categories; threads.values.flat_map { _1[:sample_categories] }; end
 
-    # Legacy format. Avoid
-    def markers
-      threads&.flat_map do |tid, thread|
-        thread[:markers] || []
-      end || []
-    end
-
     # Realtime in nanoseconds since the unix epoch
     def started_at
       started_at_mono_ns = meta[:started_at]

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -19,7 +19,7 @@ class TestActiveSupport < Minitest::Test
       ActiveSupport::Notifications.instrument("foo.bar") {}
     end
 
-    markers = result.markers.select{|x| x[1] == "foo.bar" }
+    markers = result.main_thread[:markers].select{|x| x[1] == "foo.bar" }
     assert_equal 1, markers.size
 
     marker = markers[0]
@@ -33,7 +33,7 @@ class TestActiveSupport < Minitest::Test
       ActiveSupport::Notifications.instrument("foo.bar")
     end
 
-    markers = result.markers.select{|x| x[1] == "foo.bar" }
+    markers = result.main_thread[:markers].select{|x| x[1] == "foo.bar" }
     assert_equal 1, markers.size
 
     marker = markers[0]
@@ -47,7 +47,7 @@ class TestActiveSupport < Minitest::Test
       ActiveSupport::Notifications.publish("foo.bar")
     end
 
-    markers = result.markers.select{|x| x[1] == "foo.bar" }
+    markers = result.main_thread[:markers].select{|x| x[1] == "foo.bar" }
     assert_equal 0, markers.size
   end
 

--- a/test/test_time_collector.rb
+++ b/test/test_time_collector.rb
@@ -272,6 +272,32 @@ class TestTimeCollector < Minitest::Test
     assert_equal false, result.meta[:gc]
   end
 
+  def test_switching_fibers
+    th = []
+    result = Vernier.profile do
+      2.times do
+        th << Thread.new do
+          fiber = Fiber.new do
+            Fiber.yield 1
+            2
+          end
+          fiber.resume
+          fiber.resume
+        end
+      end
+      th.each(&:join)
+    end
+
+    th.each do |thread|
+      fiber_markers = result.threads[thread.__id__][:markers].select {|x| x[1].include?("Fiber") }
+      switch = fiber_markers.select { |x| x[1].include?("Switch") }
+      running = fiber_markers.select { |x| x[1].include?("Running") }
+
+      assert_equal 4, switch.size
+      assert_equal 4, running.size
+    end
+  end
+
   private
 
   SLOW_RUNNER = ENV["GITHUB_ACTIONS"] && ENV["RUNNER_OS"] == "macOS"

--- a/test/test_time_collector.rb
+++ b/test/test_time_collector.rb
@@ -13,7 +13,7 @@ class TestTimeCollector < Minitest::Test
     assert_valid_result result
     # make sure we got all GC events (since we did GC.start twice)
     assert_equal ["GC end marking", "GC end sweeping", "GC pause", "GC start"].sort,
-      result.markers.map { |x| x[1] }.grep(/^GC/).uniq.sort
+      result.main_thread[:markers].map { |x| x[1] }.grep(/^GC/).uniq.sort
   end
 
   def test_time_collector


### PR DESCRIPTION
Fiber Running and Fiber Switch events give us information about what Fibers in the system are doing.  The Fiber Running span in the marker chart allow us to easily select work that a particular Fiber is doing, where the Fiber Switch event allows us to identify why a Fiber changed.

Here is a sample program we'll profile with Vernier:

```ruby
require "async"
require "async/queue"

def measure
  x = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  yield
  Process.clock_gettime(Process::CLOCK_MONOTONIC) - x
end

def fib(n)
  if n < 2
    n
  else
    fib(n-2) + fib(n-1)
  end
end

# find fib that takes ~50ms
fib_i = 50.times.find { |i| measure { fib(i) } >= 0.05 }
sleep_i = measure { fib(fib_i) }

Async {
  latch = Async::Queue.new

  workers = [
    Async {
      latch.pop # block until ready to measure

      100.times {
        sleep(sleep_i)
        # stalls happen here. This worker wants to be scheduled so it can
        # continue the loop, but will be blocked by another worker executing fib
      }
    },
    Async {
      latch.pop # block until ready to measure

      100.times { fib(fib_i) }
    },
  ]

  2.times { latch << nil }
  workers.each(&:wait)
}
```

The sample program has one Fiber that is CPU bound.  It's calculating Fib in a loop.  The other Fiber is simulating IO work by calling `sleep`.

Here I've highlighted the marker where we have one Fiber using the CPU for a long time:

<img width="1466" alt="Screenshot 2024-11-19 at 4 20 51 PM" src="https://github.com/user-attachments/assets/a5a75af1-37e7-4eaa-8ab8-2747a2944fa1">

Selecting that marker lets us verify that in fact it's spending time calculating Fib:

<img width="1466" alt="Screenshot 2024-11-19 at 4 23 17 PM" src="https://github.com/user-attachments/assets/c50ee8fd-dacb-4385-8f9b-12f1bfd6ad1b">
