### PR TITLE
Pause and resume profiling around forks

### DIFF
--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1927,6 +1927,12 @@ collector_resume(VALUE self) {
 }
 
 static VALUE
+collector_running_p(VALUE self) {
+    auto *collector = get_collector(self);
+    return collector->is_running() ? Qtrue : Qfalse;
+}
+
+static VALUE
 collector_stop(VALUE self) {
     auto *collector = get_collector(self);
 
@@ -2023,6 +2029,7 @@ Init_vernier(void)
   rb_define_method(rb_cVernierCollector, "start", collector_start, 0);
   rb_define_method(rb_cVernierCollector, "pause", collector_pause, 0);
   rb_define_method(rb_cVernierCollector, "resume", collector_resume, 0);
+  rb_define_method(rb_cVernierCollector, "running?", collector_running_p, 0);
   rb_define_method(rb_cVernierCollector, "sample", collector_sample, 0);
   rb_define_method(rb_cVernierCollector, "stack_table", collector_stack_table, 0);
   rb_define_private_method(rb_cVernierCollector, "finish",  collector_stop, 0);

--- a/ext/vernier/vernier.cc
+++ b/ext/vernier/vernier.cc
@@ -1168,6 +1168,7 @@ class BaseCollector {
     }
 
     public:
+    VALUE self = Qnil;
     bool running = false;
     StackTable *stack_table;
     VALUE stack_table_value;
@@ -1224,9 +1225,11 @@ class BaseCollector {
     virtual void mark() {
         //frame_list.mark_frames();
         rb_gc_mark(stack_table_value);
+        rb_gc_mark(self);
     };
 
     virtual void compact() {
+        self = rb_gc_location(self);
     };
 };
 
@@ -1930,6 +1933,7 @@ static VALUE collector_new(VALUE self, VALUE mode, VALUE options) {
         rb_raise(rb_eArgError, "invalid mode");
     }
     VALUE obj = TypedData_Wrap_Struct(self, &rb_collector_type, collector);
+    collector->self = obj;
     rb_funcall(obj, rb_intern("initialize"), 2, mode, options);
     return obj;
 }

--- a/lib/vernier.rb
+++ b/lib/vernier.rb
@@ -5,6 +5,7 @@ require_relative "vernier/collector"
 require_relative "vernier/stack_table"
 require_relative "vernier/result"
 require_relative "vernier/hooks"
+require_relative "vernier/fork"
 require_relative "vernier/vernier"
 require_relative "vernier/output/firefox"
 require_relative "vernier/output/top"
@@ -54,6 +55,11 @@ module Vernier
     @collector = nil
 
     result
+  end
+
+  def self.cancel_profile
+    @collector&.cancel
+    @collector = nil
   end
 
   def self.trace_retained(**profile_options, &block)

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -73,6 +73,15 @@ module Vernier
       )
     end
 
+    def cancel
+      finish
+      @thread_names.cancel
+      @hooks.each do |hook|
+        hook.disable
+      end
+      nil
+    end
+
     def stop
       result = finish
 

--- a/lib/vernier/fork.rb
+++ b/lib/vernier/fork.rb
@@ -6,7 +6,9 @@ module Vernier
       def _fork
         pid = super
         if pid == 0 # We're in the child
-          Vernier.cancel_profile
+          ObjectSpace.each_object(Vernier::Collector) do |collector|
+             Vernier.cancel_profile
+          end
         end
         pid
       end

--- a/lib/vernier/fork.rb
+++ b/lib/vernier/fork.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Vernier
+  if ::Process.respond_to?(:_fork)
+    module ForkHooks
+      def _fork
+        pid = super
+        if pid == 0 # We're in the child
+          Vernier.cancel_profile
+        end
+        pid
+      end
+    end
+
+    ::Process.singleton_class.prepend(ForkHooks)
+  end
+end

--- a/lib/vernier/result.rb
+++ b/lib/vernier/result.rb
@@ -61,9 +61,9 @@ module Vernier
     end
 
     class BaseType
-      attr_reader :result, :idx
-      def initialize(result, idx)
-        @result = result
+      attr_reader :stack_table, :idx
+      def initialize(stack_table, idx)
+        @stack_table = stack_table
         @idx = idx
       end
 
@@ -78,12 +78,12 @@ module Vernier
 
     class Func < BaseType
       def label
-        result._stack_table.func_name(idx)
+        stack_table.func_name(idx)
       end
       alias name label
 
       def filename
-        result._stack_table.func_filename(idx)
+        stack_table.func_filename(idx)
       end
 
       def to_s
@@ -97,12 +97,12 @@ module Vernier
       alias name label
 
       def func
-        func_idx = result._stack_table.frame_func_idx(idx)
-        Func.new(result, func_idx)
+        func_idx = stack_table.frame_func_idx(idx)
+        Func.new(stack_table, func_idx)
       end
 
       def line
-        result._stack_table.frame_line_no(idx)
+        stack_table.frame_line_no(idx)
       end
 
       def to_s
@@ -116,18 +116,18 @@ module Vernier
 
         stack_idx = idx
         while stack_idx
-          frame_idx = result._stack_table.stack_frame_idx(stack_idx)
-          yield Frame.new(result, frame_idx)
-          stack_idx = result._stack_table.stack_parent_idx(stack_idx)
+          frame_idx = stack_table.stack_frame_idx(stack_idx)
+          yield Frame.new(stack_table, frame_idx)
+          stack_idx = stack_table.stack_parent_idx(stack_idx)
         end
       end
 
       def leaf_frame_idx
-        result._stack_table.stack_frame_idx(idx)
+        stack_table.stack_frame_idx(idx)
       end
 
       def leaf_frame
-        Frame.new(result, leaf_frame_idx)
+        Frame.new(stack_table, leaf_frame_idx)
       end
 
       def frames
@@ -144,7 +144,7 @@ module Vernier
     end
 
     def stack(idx)
-      Stack.new(self, idx)
+      Stack.new(_stack_table, idx)
     end
 
     def total_bytes

--- a/lib/vernier/thread_names.rb
+++ b/lib/vernier/thread_names.rb
@@ -13,6 +13,10 @@ module Vernier
       @names[object_id] || "thread obj_id:#{object_id}"
     end
 
+    def cancel
+      @tp.disable
+    end
+
     def finish
       collect_running
       @tp.disable

--- a/test/test_fork.rb
+++ b/test/test_fork.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestFork < Minitest::Test
+  def test_that_forked_children_do_not_hang
+    Vernier.trace do
+      pid = Process.fork do
+        sleep 0.1
+        # noop
+      end
+      _, status = Process.waitpid2(pid)
+      assert_predicate status, :success?
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,10 +16,36 @@ class Minitest::Test
 
     stack_table_size = result._stack_table.stack_count
 
-    result.samples.each do |stack_idx|
-      assert_kind_of Integer, stack_idx
-      assert_operator stack_idx, :<, stack_table_size
-      assert_operator stack_idx, :>=, 0
+    assert_kind_of Integer, result.pid
+    assert_kind_of Integer, result.end_time
+    assert_kind_of Integer, result.started_at
+
+    meta = result.meta
+    assert_kind_of Hash, meta
+    mode = meta[:mode]
+    assert_kind_of Symbol, mode
+
+    threads = result.threads
+    assert_kind_of Hash, threads
+    refute_empty threads
+
+    threads.each do |tid, thread|
+      assert_kind_of Integer, thread[:tid]
+      assert_kind_of String, thread[:name]
+      assert_kind_of Integer, thread[:started_at]
+
+      assert_kind_of Array, thread[:samples]
+      assert_kind_of Array, thread[:weights]
+      unless mode == :retained
+        assert_kind_of Array, thread[:timestamps]
+        assert_kind_of Array, thread[:sample_categories]
+      end
+
+      thread[:samples].each do |stack_idx|
+        assert_kind_of Integer, stack_idx
+        assert_operator stack_idx, :<, stack_table_size
+        assert_operator stack_idx, :>=, 0
+      end
     end
   end
 end

--- a/test/test_vernier.rb
+++ b/test/test_vernier.rb
@@ -6,19 +6,4 @@ class TestVernier < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Vernier::VERSION
   end
-
-  def test_that_forked_children_do_not_hang
-    return skip
-    1000.times do
-      Vernier.trace do
-        pid = Process.fork do
-          sleep 0.1
-          # noop
-        end
-        _, status = Process.waitpid2(pid)
-        assert_predicate status, :success?
-      end
-      print "."
-    end
-  end
 end

--- a/test/test_vernier.rb
+++ b/test/test_vernier.rb
@@ -6,4 +6,12 @@ class TestVernier < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Vernier::VERSION
   end
+
+  def test_that_forked_children_do_not_hang
+    pid = Process.fork do
+      # noop
+    end
+    _, status = Process.waitpid2(pid)
+    assert_predicate status, :success?
+  end
 end

--- a/test/test_vernier.rb
+++ b/test/test_vernier.rb
@@ -8,10 +8,17 @@ class TestVernier < Minitest::Test
   end
 
   def test_that_forked_children_do_not_hang
-    pid = Process.fork do
-      # noop
+    return skip
+    1000.times do
+      Vernier.trace do
+        pid = Process.fork do
+          sleep 0.1
+          # noop
+        end
+        _, status = Process.waitpid2(pid)
+        assert_predicate status, :success?
+      end
+      print "."
     end
-    _, status = Process.waitpid2(pid)
-    assert_predicate status, :success?
   end
 end


### PR DESCRIPTION
Based on #82

I think there's more I can simplify here still. After implementing all of it I'm not sure that pause/resume need to be separate from start/stop.

I'll also want to make something more efficient than running `ObjectSpace.each_object` on every fork. This also does leave a possible race condition where if you are spawning new threads which are themselves making new profiles as you fork we may miss one to disable, but I'm reasonably happy ignoring that for now.