### PR TITLE
Add `require "vernier/autorun"` instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ written to /tmp/profile20241029-26525-dalmym.vernier.json.gz
 Vernier can be enabled globally within a Ruby script or application:
 
 ```ruby
-require "vernier/autorun
+require "vernier/autorun"
 ```
 
 For example, adding this to a Rails application's `config/application.rb` will enable Vernier during boot and output a recording when exited.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ starting profiler with interval 100 and allocation interval 10
 written to /tmp/profile20241029-26525-dalmym.vernier.json.gz
 ```
 
+#### Autorun
+
+Vernier can be enabled globally within a Ruby script or application:
+
+```ruby
+require "vernier/autorun
+```
+
+For example, adding this to a Rails application's `config/application.rb` will enable Vernier during boot and output a recording when exited.
+
 #### Block of code
 
 ``` ruby


### PR DESCRIPTION
I was helping a developer who was using `puma-dev` and we couldn't figure out how to enable Vernier from the command line. While digging around in Vernier's internals, I discovered that it could be enabled this way.