### PR TITLE
Fix failing retained memory test on head

### DIFF
--- a/test/test_retained_memory.rb
+++ b/test/test_retained_memory.rb
@@ -123,9 +123,9 @@ class TestRetainedMemory < Minitest::Test
     assert_equal expected_labels, labels.grep(/#alloc_[abc]\z/)
 
     expected_inspects = [
-      "#{self.class.name}#alloc_a at #{method(:alloc_a).source_location.join(":")}",
-      "#{self.class.name}#alloc_b at #{method(:alloc_b).source_location.join(":")}",
-      "#{self.class.name}#alloc_c at #{method(:alloc_c).source_location.join(":")}"
+      "#{self.class.name}#alloc_a at #{method(:alloc_a).source_location.first(2).join(":")}",
+      "#{self.class.name}#alloc_b at #{method(:alloc_b).source_location.first(2).join(":")}",
+      "#{self.class.name}#alloc_c at #{method(:alloc_c).source_location.first(2).join(":")}"
     ]
     assert_equal expected_inspects, inspects.grep(/#alloc_[abc]/)
   end


### PR DESCRIPTION
Example failure: https://github.com/jhawthorn/vernier/actions/runs/12829459612/job/35803700089#step:4:333

Ref:https://github.com/ruby/ruby/commit/073c4e1cc712064e626914fa4a5a8061f903a637