### PR TITLE
Separate parsing samples_by_file from output 

### DIFF
--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -28,15 +28,14 @@ module Vernier
         if Hash === thread
           # live profile
           stack_table = @profile._stack_table
-          weights = thread[:weights]
-          samples = thread[:samples]
           filename_filter = FilenameFilter.new
         else
           stack_table = thread.stack_table
-          weights = thread.weights
-          samples = thread.samples
           filename_filter = ->(x) { x }
         end
+
+        weights = thread[:weights]
+        samples = thread[:samples]
 
         self_samples_by_frame = Hash.new do |h, k|
           h[k] = SamplesByLocation.new
@@ -96,14 +95,7 @@ module Vernier
 
       def total
         thread = @profile.main_thread
-        if Hash === thread
-          # live profile
-          weights = thread[:weights]
-        else
-          weights = thread.weights
-        end
-
-        weights.sum
+        thread[:weights].sum
       end
 
       def format_file(output, filename, all_samples, total:)

--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -23,9 +23,7 @@ module Vernier
         @profile = profile
       end
 
-      def output
-        output = +""
-
+      def samples_by_file
         thread = @profile.main_thread
         if Hash === thread
           # live profile
@@ -76,6 +74,10 @@ module Vernier
         samples_by_file.transform_keys! do |filename|
           filename_filter.call(filename)
         end
+      end
+
+      def output
+        output = +""
 
         relevant_files = samples_by_file.select do |k, v|
           next if k.start_with?("gem:")
@@ -90,6 +92,18 @@ module Vernier
           format_file(output, filename, samples_by_file, total: total)
         end
         output << "="*80 << "\n"
+      end
+
+      def total
+        thread = @profile.main_thread
+        if Hash === thread
+          # live profile
+          weights = thread[:weights]
+        else
+          weights = thread.weights
+        end
+
+        weights.sum
       end
 
       def format_file(output, filename, all_samples, total:)


### PR DESCRIPTION
This PR separates `Vernier::Output::FileListing::SamplesByLocation#output` into `samples_by_file` for parsing the samples and `output` for making the actual output string, to prepare for adding more options for customizing the file listing display.