### PR TITLE
Option to display file output in html view

### DIFF
--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -120,6 +120,7 @@ module Vernier
       end
 
       def html_output(output, relevant_files)
+        output << "<pre>"
         output << "  SELF     FILE\n"
         relevant_files.sort_by {|k, v| -v.values.map(&:self).sum }.each do |filename, file_contents|
           tmpl = "<details style=\"display:inline-block;vertical-align:top;\"><summary>%s</summary>"
@@ -127,7 +128,7 @@ module Vernier
           format_file_html(output, filename, relevant_files)
           output << "</details>\n"
         end
-        output
+        output << "</pre>"
       end
 
       def format_file_html(output, filename, relevant_files)

--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -122,7 +122,7 @@ module Vernier
       def html_output(output, relevant_files)
         output << "  SELF     FILE\n"
         relevant_files.sort_by {|k, v| -v.values.map(&:self).sum }.each do |filename, file_contents|
-          tmpl = "<details style=\"display:inline-block;\"><summary>%s</summary>"
+          tmpl = "<details style=\"display:inline-block;vertical-align:top;\"><summary>%s</summary>"
           output << sprintf("% 5.1f%%   #{tmpl}\n", file_contents.values.map(&:self).sum * 100 / total.to_f, filename)
           format_file_html(output, filename, relevant_files)
           output << "</details>\n"

--- a/test/output/test_file_listing.rb
+++ b/test/output/test_file_listing.rb
@@ -3,38 +3,58 @@
 require "test_helper"
 
 class TestOutputFileListing < Minitest::Test
-  def test_complex_profile
-    result = Vernier.trace do
-      # Proper Ruby sleep
-      sleep 0.01
+  describe "with a live profile" do
+    before do
+      @result = Vernier.trace do
+        # Proper Ruby sleep
+        sleep 0.01
 
-      # Sleep inside rb_thread_call_without_gvl
-      GVLTest.sleep_without_gvl(0.01)
+        # Sleep inside rb_thread_call_without_gvl
+        GVLTest.sleep_without_gvl(0.01)
 
-      # Sleep with GVL held
-      GVLTest.sleep_holding_gvl(0.01)
+        # Sleep with GVL held
+        GVLTest.sleep_holding_gvl(0.01)
 
-      # Ruby busy sleep
-      target = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 0.01
-      while Process.clock_gettime(Process::CLOCK_MONOTONIC) < target
+        # Ruby busy sleep
+        target = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 0.01
+        while Process.clock_gettime(Process::CLOCK_MONOTONIC) < target
+        end
       end
     end
 
-    output = Vernier::Output::FileListing.new(result).output
-    assert_match(/\d+\.\d% \| *\d+\.\d% \| *\d+ +sleep 0\.01/, output)
-    assert_match(/\d+\.\d% \| *\d+\.\d% \| *\d+ +GVLTest\.sleep_without_gvl/, output)
-    assert_match(/\d+\.\d% \| *\d+\.\d% \| *\d+ +GVLTest\.sleep_holding_gvl/, output)
-    assert_match(/\d+\.\d% \| *\d+\.\d% \| *\d+ +while Process\.clock_gettime/, output)
+    def test_complex_profile
+      output = Vernier::Output::FileListing.new(@result).output
+      assert_match(/\d+\.\d% \| *\d+\.\d% \| *\d+ +sleep 0\.01/, output)
+      assert_match(/\d+\.\d% \| *\d+\.\d% \| *\d+ +GVLTest\.sleep_without_gvl/, output)
+      assert_match(/\d+\.\d% \| *\d+\.\d% \| *\d+ +GVLTest\.sleep_holding_gvl/, output)
+      assert_match(/\d+\.\d% \| *\d+\.\d% \| *\d+ +while Process\.clock_gettime/, output)
+    end
+
+    def test_html_output
+      output = Vernier::Output::FileListing.new(@result).output(template: "html")
+      assert_match(/<details style=\"display:inline-block;\"><summary>.+#{Regexp.escape(File.basename(__FILE__))}<\/summary>/, output)
+    end
   end
 
-  def test_parsed_profile
-    profile = Vernier::ParsedProfile.read_file(fixture_path("gvl_sleep.vernier.json"))
-    output = Vernier::Output::FileListing.new(profile).output
-    assert_includes output, <<TEXT
+  describe "with a parsed profile" do
+    before do
+      @profile = Vernier::ParsedProfile.read_file(fixture_path("gvl_sleep.vernier.json"))
+    end
+    
+    def test_parsed_profile
+      output = Vernier::Output::FileListing.new(@profile).output
+      assert_includes output, <<TEXT
  24.8% |   0.0% |   44  run(:cfunc_sleep_gvl)
  24.7% |   0.0% |   45  run(:cfunc_sleep_idle)
  24.6% |   0.0% |   46  run(:ruby_sleep_gvl)
  24.7% |   0.0% |   47  run(:sleep_idle)
 TEXT
+    end
+
+    def test_html_output
+      output = Vernier::Output::FileListing.new(@profile).output(template: "html")
+      assert_includes output,
+        " 24.5%   <details style=\"display:inline-block;\"><summary>examples/gvl_sleep.rb</summary>\n"
+    end
   end
 end

--- a/test/output/test_file_listing.rb
+++ b/test/output/test_file_listing.rb
@@ -32,7 +32,7 @@ class TestOutputFileListing < Minitest::Test
 
     def test_html_output
       output = Vernier::Output::FileListing.new(@result).output(template: "html")
-      assert_match(/<details style=\"display:inline-block;\"><summary>.+#{Regexp.escape(File.basename(__FILE__))}<\/summary>/, output)
+      assert_match(/<details style=\"display:inline-block;vertical-align:top;\"><summary>.+#{Regexp.escape(File.basename(__FILE__))}<\/summary>/, output)
     end
   end
 
@@ -54,7 +54,7 @@ TEXT
     def test_html_output
       output = Vernier::Output::FileListing.new(@profile).output(template: "html")
       assert_includes output,
-        " 24.5%   <details style=\"display:inline-block;\"><summary>examples/gvl_sleep.rb</summary>\n"
+        " 24.5%   <details style=\"display:inline-block;vertical-align:top;\"><summary>examples/gvl_sleep.rb</summary>\n"
     end
   end
 end


### PR DESCRIPTION
Adds the option to display `Vernier::Output::FileListing` in HTML. 

Each file's content is initially hidden in a details view: 
<img width="899" alt="html file view when closed" src="https://github.com/user-attachments/assets/ef27d1e7-47cb-4286-a11d-3d0f7d079305" />

Open:
<img width="1511" alt="html file view when open src="https://github.com/user-attachments/assets/8363015a-0667-4c27-879d-82a89d40b11b" />
