### PR TITLE
Customize relevant files

### DIFF
--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -20,9 +20,9 @@ module Vernier
         end
       end
 
-      def initialize(profile, relevant_files_filter: method(:default_relevant_files_filter))
+      def initialize(profile, relevant_files_filter: nil)
         @profile = profile
-        @relevant_files_filter = relevant_files_filter
+        @relevant_files_filter ||= -> (*) { default_relevant_files_filter(*) }
       end
 
       def samples_by_file

--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -20,8 +20,9 @@ module Vernier
         end
       end
 
-      def initialize(profile)
+      def initialize(profile, relevant_files_filter: method(:default_relevant_files_filter))
         @profile = profile
+        @relevant_files_filter = relevant_files_filter
       end
 
       def samples_by_file
@@ -77,11 +78,9 @@ module Vernier
       def output(template: nil)
         output = +""
 
-        relevant_files = samples_by_file.select do |k, v|
-          next if k.start_with?("gem:")
-          next if k.start_with?("rubylib:")
-          next if k.start_with?("<")
-          v.values.map(&:total).sum > total * 0.01
+        relevant_files = samples_by_file.select do |filename, v|
+          @relevant_files_filter.call(filename) &&
+            v.values.map(&:total).sum > total * 0.01
         end
 
         if template == "html"
@@ -95,6 +94,12 @@ module Vernier
           end
           output << "="*80 << "\n"
         end
+      end
+
+      def default_relevant_files_filter(filename)
+        !filename.start_with?("gem:") &&
+          !filename.start_with?("rubylib:") &&
+          !filename.start_with?("<")
       end
 
       def total

--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -121,7 +121,7 @@ module Vernier
           else
             output << sprintf("       |        | % 4i  %s", lineno, line)
           end
-        end
+        end if File.exist?(filename)
       end
 
       def html_output(output, relevant_files)
@@ -150,7 +150,7 @@ module Vernier
           else
             output << sprintf("       |        | % 4i  %s", lineno, CGI::escapeHTML(line))
           end
-        end
+        end if File.exist?(filename)
       end
     end
   end


### PR DESCRIPTION
Allows `Vernier::Output::FileListing` to be initialized with a custom relevant files filter by filename, so that the files to included in the display can be customized.

A few things that the filter does not handle right now - 

1. The relevant files filter current only considers the file name, and does not allow the sample threshold to be customized, because the total on `Output::FileListing` accessible after `Output::FileListing` is initialized. It may make sense to add `total` to the profile/result. There is already a [`total_bytes`](https://github.com/jhawthorn/vernier/blob/main/lib/vernier/result.rb#L62-L64) on `Vernier::Result`, but looks like there is [a todo to remove it](https://github.com/jhawthorn/vernier/blob/main/lib/vernier/result.rb#L19-L20). Can we keep it? Can we move the entire concept of "total" from an output to the profile/result?

2. [When we parse `samples_by_file`](https://github.com/ywenc/vernier/blob/5a3bd454e16d230a75533fc75051579f6336db7e/lib/vernier/output/file_listing.rb#L76-L78), the file names from a live profile are [changed](https://github.com/ywenc/vernier/blob/5a3bd454e16d230a75533fc75051579f6336db7e/lib/vernier/output/filename_filter.rb#L15) by the `FilenameFilter`. When we display, we need to [open the files](https://github.com/ywenc/vernier/blob/5a3bd454e16d230a75533fc75051579f6336db7e/lib/vernier/output/file_listing.rb#L100) to read the lines, which may not exist under the changed file name. Should we allow FilenameFilter to also be overridden? Would we have both a relevant file names filter + a file name filter?