### PR TITLE
Ensure Firefox frame table subcategory fields are always included

### DIFF
--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -487,17 +487,21 @@ module Vernier
         def frame_table
           funcs = @stack_table_hash[:frame_table].fetch(:func)
           lines = @stack_table_hash[:frame_table].fetch(:line)
-          size = funcs.length
-          none = [nil] * size
-          categories = @frame_categories.map(&:idx)
-
           raise unless lines.size == funcs.size
 
+          size = funcs.size
+          none = [nil] * size
+          default = [0] * size
+          unidentified = [-1] * size
+
+          categories = @frame_categories.map(&:idx)
+          subcategories = @frame_subcategories
+
           {
-            address: [-1] * size,
-            inlineDepth: [0] * size,
+            address: unidentified,
+            inlineDepth: default,
             category: categories,
-            subcategory: nil,
+            subcategory: subcategories,
             func: funcs,
             nativeSymbol: none,
             innerWindowID: none,

--- a/test/firefox_test_helpers.rb
+++ b/test/firefox_test_helpers.rb
@@ -62,6 +62,7 @@ module FirefoxTestHelpers
       assert_equal frame_length, thread["frameTable"]["innerWindowID"].length
       assert_equal frame_length, thread["frameTable"]["func"].length
       assert_equal frame_length, thread["frameTable"]["category"].length
+      assert_equal frame_length, thread["frameTable"]["subcategory"].length
       assert_equal frame_length, thread["frameTable"]["inlineDepth"].length
       assert_equal frame_length, thread["frameTable"]["address"].length
 


### PR DESCRIPTION
Closes https://github.com/jhawthorn/vernier/issues/128

I wonder why we set the frame category but not the subcategory here 🤔 ~Anyway, I've kept it as `nil` to maintain behaviour while ensuring we conform to the expected Firefox type.~ See https://github.com/jhawthorn/vernier/pull/129#issuecomment-2661156921.