### PR TITLE
Add CI build for YJIT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    name: Ruby ${{ matrix.ruby }}${{ matrix.mn_threads == 1 && ' +MN' || '' }} ${{ matrix.os }}
+    name: Ruby ${{ matrix.ruby }}${{ matrix.yjit == 1 && ' +YJIT' || '' }}${{ matrix.mn_threads == 1 && ' +MN' || '' }} ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -19,9 +19,12 @@ jobs:
           - "3.3.7"
           - "3.4.2"
           - "head"
+
         os:
           - ubuntu-latest
           - macos-latest
+
+        yjit: [0]
         mn_threads: [0]
 
         include:
@@ -31,6 +34,13 @@ jobs:
           - os: ubuntu-latest
             ruby: "head"
             mn_threads: 1
+
+          - os: ubuntu-latest
+            ruby: "3.4.2"
+            yjit: 1
+          - os: ubuntu-latest
+            ruby: "head"
+            yjit: 1
 
     steps:
       - uses: actions/checkout@v2
@@ -42,4 +52,5 @@ jobs:
       - name: Run the default task
         run: bundle exec rake
         env:
+          RUBY_YJIT_ENABLE: ${{ matrix.yjit }}
           RUBY_MN_THREADS: ${{ matrix.mn_threads }}

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -161,12 +161,12 @@ class TestStackTable < Minitest::Test
     end
 
     # Replace cfunc with previous frame as caller_locations does
-    prev = "<cfunc>:0"
+    prev = nil
     actual.reverse_each do |line|
-      if line.start_with?("<cfunc>:0")
+      if prev && line.start_with?("<cfunc>:0")
         line.gsub!(/\A<cfunc>:0/, prev)
-      elsif line.start_with?("<internal:")
-        line.gsub!(/\A<internal:[^>]*>/, "")
+      elsif prev && line.start_with?("<internal:")
+        line.gsub!(/\A<internal:[^>]*>:\d+/, prev)
       else
         prev = line[/\A(.*):in '/, 1]
       end


### PR DESCRIPTION
Since many ruby core methods are being re-written in ruby for when YJIT is enabled, I think it might be a good idea to run a build for the latest release and head with it enabled to catch any behavioural changes e.g. caller location entries like in [the test that fails on this branch](https://github.com/jhawthorn/vernier/actions/runs/14006305734/job/39220608434?pr=135#step:4:36).