### PR TITLE
Avoid `JSON.fast_generate`

### DIFF
--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -93,7 +93,7 @@ module Vernier
       end
 
       def output(gzip: false)
-        result = ::JSON.fast_generate(data)
+        result = ::JSON.generate(data)
         if gzip
           require "zlib"
           result = Zlib.gzip(result)


### PR DESCRIPTION
Fix: https://github.com/jhawthorn/vernier/issues/147

It's deprecated for JSON 3.0. It never was significantly faster than `JSON.generate` it only disabled depth checks.