### PR TITLE
Require `cgi/esacpe` instead of `cgi/util`

### DIFF
--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "filename_filter"
-require "cgi/util"
+require "cgi/escape"
 
 module Vernier
   module Output


### PR DESCRIPTION
The util one emits a warning on Ruby 3.5

https://bugs.ruby-lang.org/issues/21258

There's one test failure because of https://bugs.ruby-lang.org/issues/21254 (inlining Class#new) on Ruby 3.5 which is unrelated.