### PR TITLE
Drop `base64` dependency

### DIFF
--- a/exe/vernier
+++ b/exe/vernier
@@ -9,10 +9,9 @@ module Vernier
   module CLI
     class Metadata < Array
       require 'json'
-      require 'base64'
 
       def to_s
-        Base64.encode64(to_json)
+        [to_json].pack("m")
       end
     end
 

--- a/lib/vernier/autorun.rb
+++ b/lib/vernier/autorun.rb
@@ -1,6 +1,5 @@
 require "tempfile"
 require "vernier"
-require "base64"
 require "json"
 
 module Vernier
@@ -22,7 +21,7 @@ module Vernier
       allocation_interval = options.fetch(:allocation_interval, 0).to_i
       hooks = options.fetch(:hooks, "").split(",")
       metadata = if options[:metadata]
-        JSON.parse(Base64.decode64(@options[:metadata])).to_h { |k, v| [k.to_sym, v] }
+        JSON.parse(@options[:metadata].unpack1("m")).to_h { |k, v| [k.to_sym, v] }
       else
         {}
       end


### PR DESCRIPTION
I tried to run `vernier` with Ruby 3.4, but I got the following warning.

```bash
$ vernier run -- bundle exec ruby -ve 'sleep 1'
/home/yyagi/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/vernier-1.7.1/lib/vernier/autorun.rb:3: warning: base64 was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
```

As the warning describes, `vernier` uses `base64`, but it's not added to the dependency.
`vernier` uses `base64` only in two places. So I changed those not using `base64` instead of adding a dependency.

Ref:

* https://github.com/ruby/base64/blob/cd65c103c571f8451fec796e5685db9a3047128d/lib/base64.rb#L219-L221
* https://github.com/ruby/base64/blob/cd65c103c571f8451fec796e5685db9a3047128d/lib/base64.rb#L241-L243