### PR TITLE
refactor: rename to_gecko to to_firefox

### DIFF
--- a/lib/vernier/middleware.rb
+++ b/lib/vernier/middleware.rb
@@ -18,7 +18,7 @@ module Vernier
       result = Vernier.trace(interval:, allocation_interval:, hooks: [:rails]) do
         @app.call(env)
       end
-      body = result.to_gecko(gzip: true)
+      body = result.to_firefox(gzip: true)
       filename = "#{request.path.gsub("/", "_")}_#{DateTime.now.strftime("%Y-%m-%d-%H-%M-%S")}.vernier.json.gz"
       headers = {
         "Content-Type" => "application/octet-stream",

--- a/lib/vernier/result.rb
+++ b/lib/vernier/result.rb
@@ -29,13 +29,14 @@ module Vernier
       (current_time_real_ns - current_time_mono_ns + started_at_mono_ns)
     end
 
-    def to_gecko(gzip: false)
+    def to_firefox(gzip: false)
       Output::Firefox.new(self).output(gzip:)
     end
+    alias_method :to_gecko, :to_firefox
 
     def write(out:)
       gzip = out.end_with?(".gz")
-      File.binwrite(out, to_gecko(gzip:))
+      File.binwrite(out, to_firefox(gzip:))
     end
 
     def elapsed_seconds


### PR DESCRIPTION
In preparation for other output formats, I'd like to rename `to_gecko` to `to_firefox` so it's a little more consistent with the intended use (Firefox Profiler being the target). Gecko might be a little esoteric.

I'm aliasing `to_gecko` so it's not a breaking change, but happy to remove that if we want to remove it, or add a more formal deprecation if we feel we need it