### PR TITLE
Add support for -v and --version flags

### DIFF
--- a/exe/vernier
+++ b/exe/vernier
@@ -87,6 +87,8 @@ run = Vernier::CLI.run(options)
 view = Vernier::CLI.view(options)
 
 case ARGV.shift
+when "-v", "--version"
+  puts Vernier::VERSION
 when "run"
   run.parse!
   run.abort(run.help) if ARGV.empty?


### PR DESCRIPTION
This is part of the effort to add vernier support to Ruby LSP ([see here](https://github.com/jhawthorn/vernier/pull/154)), which requires the LSP to check if the installed version of vernier supports the `cpuprofile` format.

I've added `-v` and `--version` flags to vernier, which will output the following:

```
$ exe/vernier -v
1.7.1
```

On older versions, this will not show a version.