### PR TITLE
Fix the row limit in the CLI profile output

### DIFF
--- a/exe/vernier
+++ b/exe/vernier
@@ -79,7 +79,7 @@ FLAGS:
 
       parsed_profile = Vernier::ParsedProfile.read_file(file)
 
-      puts Vernier::Output::Top.new(parsed_profile).output
+      puts Vernier::Output::Top.new(parsed_profile, top).output
       puts Vernier::Output::FileListing.new(parsed_profile).output
     end
   end

--- a/lib/vernier/output/top.rb
+++ b/lib/vernier/output/top.rb
@@ -3,14 +3,16 @@
 module Vernier
   module Output
     class Top
-      def initialize(profile)
+      def initialize(profile, row_limit)
         @profile = profile
+        @row_limit = row_limit
       end
 
       class Table
-        def initialize(header)
+        def initialize(header, row_limit)
           @header = header
           @rows = []
+          @row_limit = row_limit
           yield self
         end
 
@@ -24,7 +26,7 @@ module Vernier
               row_separator,
               format_row(@header),
               row_separator
-            ] + @rows.map do |row|
+            ] + @rows.first(@row_limit).map do |row|
               format_row(row)
             end + [row_separator]
           ).join("\n")
@@ -70,7 +72,7 @@ module Vernier
           top_by_self[name] += weight
         end
 
-        Table.new %w[Samples % name] do |t|
+        Table.new %w[Samples % name], @row_limit do |t|
           top_by_self.sort_by(&:last).reverse.each do |frame, samples|
             pct = 100.0 * samples / total
             t << [samples.to_s, pct.round(1).to_s, frame]

--- a/test/output/test_top.rb
+++ b/test/output/test_top.rb
@@ -22,7 +22,7 @@ class TestOutputTop < Minitest::Test
       end
     end
 
-    output = Vernier::Output::Top.new(result).output
+    output = Vernier::Output::Top.new(result, 20).output
     assert_match(/^| \d+ *\| \d+\.\d *\| GVLTest\.sleep_without_gvl *\|$/, output)
     assert_match(/^| \d+ *\| \d+\.\d *\| GVLTest\.sleep_holding_gvl *\|$/, output)
     assert_match(/^| \d+ *\| \d+\.\d *\| Kernel#sleep *\|$/, output)
@@ -31,7 +31,7 @@ class TestOutputTop < Minitest::Test
 
   def test_parsed_profile
     profile = Vernier::ParsedProfile.read_file(fixture_path("gvl_sleep.vernier.json"))
-    output = Vernier::Output::Top.new(profile).output
+    output = Vernier::Output::Top.new(profile, 20).output
     assert_includes output, "| 2013    | 24.8 | GVLTest.sleep_holding_gvl"
     assert_includes output, "| 2010    | 24.7 | Kernel#sleep"
     assert_includes output, "| 2010    | 24.7 | GVLTest.sleep_without_gvl"


### PR DESCRIPTION
We're supposed to be limiting the number of rows in the output to a default of 20, but it seems like we were just throwing the limit away 😅

This commit respects the row limit in the CLI output