### PR TITLE
Fix tests: install vernier.gem before running

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/test_*.rb"]
-  t.deps << :compile
+  t.deps << :install
 end
 
 task :console => :compile do
@@ -17,9 +17,10 @@ end
 require "rake/extensiontask"
 
 task build: :compile
+task install: :compile
 
 Rake::ExtensionTask.new("vernier") do |ext|
   ext.lib_dir = "lib/vernier"
 end
 
-task default: %i[clobber compile test]
+task default: %i[clobber compile install test]

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -51,7 +51,7 @@ class IntegrationTest < Minitest::Test
   def vernier_run(*argv)
     result_json = nil
     Tempfile.open('vernier') do |tempfile|
-      system('vernier', 'run', '--output', tempfile.path, *argv, out: '/dev/null', err: '/dev/null')
+      system('vernier', 'run', '--output', tempfile.path, *argv, exception: true, out: '/dev/null', err: '/dev/null')
       tempfile.rewind
       result_json = tempfile.read
     end


### PR DESCRIPTION
`rake test` in a new repo had errors. Install the gem before running the tests because the integration tests depend on it being installed.