### PR TITLE
Rebuild HeapTracker's lists/map at drain time

### DIFF
--- a/ext/vernier/heap_tracker.cc
+++ b/ext/vernier/heap_tracker.cc
@@ -140,6 +140,9 @@ class HeapTracker {
       if (RTEST(tp_newobj)) {
         rb_tracepoint_disable(tp_newobj);
         tp_newobj = Qnil;
+        if (tombstones * 10 > object_list.size()) {
+          rebuild();
+        }
       }
     }
 


### PR DESCRIPTION
Since drain happens only once and there could be many tombstones, we may as well rebuild. The data structures will no longer grow from now on, and we might not hit enough freeing for it to trigger a rebuild through `freeobj`.