### PR TITLE
HeapTracker: Call `lock` before `data`

### DIFF
--- a/ext/vernier/heap_tracker.cc
+++ b/ext/vernier/heap_tracker.cc
@@ -174,7 +174,7 @@ class HeapTracker {
     }
 
     VALUE data() {
-      // TOOD: should this ensure we are paused or stopped?
+      assert(stopped);
       VALUE hash = rb_hash_new();
       VALUE samples = rb_ary_new();
       rb_hash_aset(hash, sym("samples"), samples);
@@ -183,8 +183,8 @@ class HeapTracker {
 
       for (int i = 0; i < object_list.size(); i++) {
         VALUE obj = object_list[i];
-        VALUE stack_index = frame_list[i];
         if (obj == Qfalse) continue;
+        VALUE stack_index = frame_list[i];
 
         rb_ary_push(samples, INT2NUM(stack_index));
         rb_ary_push(weights, INT2NUM(rb_obj_memsize_of(obj)));

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -66,12 +66,12 @@ module Vernier
 
         GC.start
 
-        stack_table.finalize
+        @stack_table.finalize
 
         GC.start
 
-        tracker_data = @heap_tracker.data
         @heap_tracker.lock
+        tracker_data = @heap_tracker.data
 
         samples = tracker_data.fetch(:samples)
         weights = tracker_data.fetch(:weights)


### PR DESCRIPTION
When we iterate over `object_list` in `HeapTracker::data`, we can't record any freeobj events during the iteration or else `object_list` could get resized and we could get out of bounds access. `rb_ary_push` can lead to GC, so turn off the `freeobj` event before doing this.