### PR TITLE
Add an option for hiding anonymous threads in profile output

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ See [`examples/custom_hook.rb`](examples/custom_hook.rb) for a complete example.
 | `allocation_interval` | `vernier_allocation_interval` | Allocation sampling interval. Only in `:wall` mode.           | `0` i.e. disabled (`200`)    |
 | `gc`                  | N/A                           | Run full GC cycle before profiling. Only in `:retained` mode. | `true` (N/A)                 |
 | `metadata`            | N/A                           | Metadata key-value pairs to include in the profile.           | `{}` (N/A)                   |
+| `hide_anonymous_threads` | N/A                        | Anonymous threads will be initially hidden in profile output. | `false` (N/A)                |
 
 #### Hook options
 

--- a/exe/vernier
+++ b/exe/vernier
@@ -51,6 +51,9 @@ FLAGS:
           options[:metadata] ||= Metadata.new
           options[:metadata] << [key, value]
         end
+        o.on('--hide-anonymous-threads', "Anonymous threads will be initially hidden in profiles") do
+          options[:hide_anonymous_threads] = true
+        end
         o.on('--format [FORMAT]', String, "output format: firefox (default) or cpuprofile") do |output_format|
           options[:format] = output_format
         end

--- a/lib/vernier/autorun.rb
+++ b/lib/vernier/autorun.rb
@@ -20,6 +20,7 @@ module Vernier
       interval = options.fetch(:interval, 500).to_i
       allocation_interval = options.fetch(:allocation_interval, 0).to_i
       hooks = options.fetch(:hooks, "").split(",")
+      hide_anonymous_threads = options[:hide_anonymous_threads] || false
       metadata = if options[:metadata]
         JSON.parse(@options[:metadata].unpack1("m")).to_h { |k, v| [k.to_sym, v] }
       else
@@ -28,7 +29,7 @@ module Vernier
 
       STDERR.puts("starting profiler with interval #{interval} and allocation interval #{allocation_interval}")
 
-      @collector = Vernier::Collector.new(:wall, interval:, allocation_interval:, hooks:, metadata:)
+      @collector = Vernier::Collector.new(:wall, interval:, allocation_interval:, hooks:, metadata:, hide_anonymous_threads:)
       @collector.start
     end
 

--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -116,6 +116,7 @@ module Vernier
       @mode = mode
       @out = options[:out]
       @format = options[:format]
+      @hide_anonymous_threads = options[:hide_anonymous_threads]
 
       @markers = []
       @hooks = []
@@ -193,6 +194,7 @@ module Vernier
       result.meta[:out] = @out
       result.meta[:gc] = @gc
       result.meta[:user_metadata] = @user_metadata
+      result.meta[:hide_anonymous_threads] = @hide_anonymous_threads
 
       result.stack_table = stack_table
       @thread_names.finish
@@ -203,6 +205,7 @@ module Vernier
 
       result.threads.each do |obj_id, thread|
         thread[:name] ||= @thread_names[obj_id]
+        thread[:anonymous] ||= @thread_names.anonymous?(obj_id)
       end
 
       result.hooks = @hooks

--- a/lib/vernier/thread_names.rb
+++ b/lib/vernier/thread_names.rb
@@ -3,6 +3,7 @@ module Vernier
   class ThreadNames
     def initialize
       @names = {}
+      @anonymous = {}
       @tp = TracePoint.new(:thread_end) do |e|
         collect_thread(e.self)
       end
@@ -11,6 +12,10 @@ module Vernier
 
     def [](object_id)
       @names[object_id] || "thread obj_id:#{object_id}"
+    end
+
+    def anonymous?(object_id)
+      @anonymous[object_id]
     end
 
     def finish
@@ -27,6 +32,7 @@ module Vernier
     end
 
     def collect_thread(th)
+      @anonymous[th.object_id] = !th.name
       @names[th.object_id] = pretty_name(th)
     end
 

--- a/test/output/test_firefox.rb
+++ b/test/output/test_firefox.rb
@@ -97,6 +97,19 @@ class TestOutputFirefox < Minitest::Test
     assert_valid_firefox_profile(output)
   end
 
+  def test_anonymous_threads_are_hidden
+    result = Vernier.trace(hide_anonymous_threads: true) do
+      th1 = Thread.new { Thread.current.name = "not anonymous"; sleep 0.01 }
+      th2 = Thread.new { sleep 0.02 }
+      th1.join
+      th2.join
+    end
+    assert result.meta[:hide_anonymous_threads]
+
+    output = JSON.parse(Vernier::Output::Firefox.new(result).output)
+    assert_equal 2, output["meta"]["initialVisibleThreads"].length
+  end
+
   def test_threaded_timed_firefox_output
     result = Vernier.trace do
       th1 = Thread.new { sleep 0.01 }


### PR DESCRIPTION
This commit adds an option for initially hiding anonymous threads in profile output.  This is particularly useful for profiling RubyGems / Bundler because most threads that do real work have names associated with them.  However, some routines like the popen family will [spawn a watchdog thread](https://github.com/ruby/ruby/blob/04e90fe200d736db0a32a794b8dc742fa0cb5441/lib/open3.rb#L535), and these watchdog threads clutter the profile output.

Before this patch:

<img width="1771" height="1273" alt="Screenshot 2026-01-04 at 2 52 55 PM" src="https://github.com/user-attachments/assets/65ffbd86-7702-4bdf-9370-e40ce2c3e08e" />

After this patch:

<img width="1771" height="1273" alt="Screenshot 2026-01-04 at 2 54 31 PM" src="https://github.com/user-attachments/assets/7af19870-b763-4733-b23e-49f440e6f87b" />

Watchdog threads are still available from the "tracks" dropdown (if you want to see them):

<img width="1771" height="1273" alt="Screenshot 2026-01-04 at 2 55 19 PM" src="https://github.com/user-attachments/assets/15866233-89bc-43d2-aeda-ee568fb1b1fe" />
