### PR TITLE
Speed up `vernier view`

### DIFF
--- a/lib/vernier/collector.rb
+++ b/lib/vernier/collector.rb
@@ -29,6 +29,7 @@ module Vernier
         result.instance_variable_set(:@threads, {
           0 => {
             tid: 0,
+            is_main: true,
             name: "custom",
             started_at: @started_at,
             samples: @samples,
@@ -80,6 +81,7 @@ module Vernier
         result.instance_variable_set(:@threads, {
           0 => {
             tid: 0,
+            is_main: true,
             name: "retained memory",
             started_at: @started_at,
             samples: samples,

--- a/lib/vernier/output/cpuprofile.rb
+++ b/lib/vernier/output/cpuprofile.rb
@@ -1,8 +1,12 @@
 require "json"
 
+require_relative "../output_helpers"
+
 module Vernier
   module Output
     class Cpuprofile
+      include OutputHelpers
+
       def initialize(profile)
         @profile = profile
       end
@@ -98,7 +102,9 @@ module Vernier
         line = stack_table.frame_line_no(frame_idx) - 1
 
         func_name = stack_table.func_name(func_idx)
+        func_name = sanitize_string(func_name) if func_name
         filename = stack_table.func_filename(func_idx)
+        filename = sanitize_string(filename) if filename
 
         node_id = nodes.length
         node = {

--- a/lib/vernier/output/file_listing.rb
+++ b/lib/vernier/output/file_listing.rb
@@ -1,22 +1,18 @@
 # frozen_string_literal: true
 
 require_relative "filename_filter"
+require_relative "../output_helpers"
 require "cgi/escape"
 
 module Vernier
   module Output
     class FileListing
+      include OutputHelpers
+
       class SamplesByLocation
         attr_accessor :self, :total
         def initialize
           @self = @total = 0
-        end
-
-        def +(other)
-          ret = SamplesByLocation.new
-          ret.self = @self + other.self
-          ret.total = @total + other.total
-          ret
         end
       end
 
@@ -25,6 +21,8 @@ module Vernier
       end
 
       def samples_by_file
+        return @samples_by_file if defined?(@samples_by_file)
+
         thread = @profile.main_thread
         if Hash === thread
           # live profile
@@ -38,22 +36,9 @@ module Vernier
         weights = thread[:weights]
         samples = thread[:samples]
 
-        self_samples_by_frame = Hash.new do |h, k|
-          h[k] = SamplesByLocation.new
-        end
+        stack_weights = collapse_stack_weights(samples, weights)
 
-        samples.zip(weights).each do |stack_idx, weight|
-          # self time
-          top_frame_index = stack_table.stack_frame_idx(stack_idx)
-          self_samples_by_frame[top_frame_index].self += weight
-
-          # total time
-          while stack_idx
-            frame_idx = stack_table.stack_frame_idx(stack_idx)
-            self_samples_by_frame[frame_idx].total += weight
-            stack_idx = stack_table.stack_parent_idx(stack_idx)
-          end
-        end
+        self_by_frame, total_by_frame = frame_weights(stack_table, stack_weights)
 
         samples_by_file = Hash.new do |h, k|
           h[k] = Hash.new do |h2, k2|
@@ -61,17 +46,62 @@ module Vernier
           end
         end
 
-        self_samples_by_frame.each do |frame, samples|
+        self_by_frame.each_with_index do |self_weight, frame|
+          total_weight = total_by_frame[frame]
+          next if self_weight == 0 && total_weight == 0
+
           line = stack_table.frame_line_no(frame)
           func_index = stack_table.frame_func_idx(frame)
           filename = stack_table.func_filename(func_index)
 
-          samples_by_file[filename][line] += samples
+          location = samples_by_file[filename][line]
+          location.self += self_weight
+          location.total += total_weight
         end
 
-        samples_by_file.transform_keys! do |filename|
+        @samples_by_file = samples_by_file.transform_keys! do |filename|
           filename_filter.call(filename)
         end
+      end
+
+      # Returns [self_weight, total_weight] arrays indexed by frame, from a
+      # hash of per-stack weights.
+      #
+      # The stack table is a prefix tree whose parent is always interned
+      # before its children (parent idx < child idx), so total weights are
+      # accumulated bottom-up in a single reverse pass.
+      private def frame_weights(stack_table, stack_weights)
+        # Scatter the sparse weights into an array indexed by stack.
+        stack_totals = Array.new(stack_table.stack_count, 0)
+        stack_weights.each do |stack_idx, weight|
+          stack_totals[stack_idx] = weight
+        end
+
+        # Accumulate each stack's total into its parent, children first,
+        # so a single descending pass completes every subtree's total.
+        (stack_totals.length - 1).downto(0) do |stack_idx|
+          parent_idx = stack_table.stack_parent_idx(stack_idx)
+          next unless parent_idx
+
+          if parent_idx >= stack_idx
+            raise "Invalid profile: stack table is not parent-before-child ordered"
+          end
+
+          stack_totals[parent_idx] += stack_totals[stack_idx]
+        end
+
+        self_by_frame = Array.new(stack_table.frame_count, 0)
+        total_by_frame = Array.new(stack_table.frame_count, 0)
+        stack_weights.each do |stack_idx, weight|
+          self_by_frame[stack_table.stack_frame_idx(stack_idx)] += weight
+        end
+        stack_totals.each_with_index do |total, stack_idx|
+          next if total == 0
+
+          total_by_frame[stack_table.stack_frame_idx(stack_idx)] += total
+        end
+
+        [self_by_frame, total_by_frame]
       end
 
       def output(template: nil)
@@ -98,8 +128,7 @@ module Vernier
       end
 
       def total
-        thread = @profile.main_thread
-        thread[:weights].sum
+        @total ||= @profile.main_thread[:weights].sum
       end
 
       def format_file(output, filename, all_samples, total:)

--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -4,6 +4,7 @@ require "json"
 require "rbconfig"
 
 require_relative "filename_filter"
+require_relative "../output_helpers"
 
 module Vernier
   module Output
@@ -267,6 +268,8 @@ module Vernier
       end
 
       class Thread
+        include OutputHelpers
+
         SAMPLE_CATEGORY_NAMES = {
           1 => "Idle",
           2 => "Stalled"
@@ -638,18 +641,7 @@ module Vernier
 
         def string_table
           @strings.keys.map do |string|
-            if string.ascii_only?
-              string
-            elsif string.encoding == Encoding::UTF_8
-              if string.valid_encoding?
-                string
-              else
-                string.scrub
-              end
-            else
-              # TODO: We might want to guess UTF-8 and escape the binary more explicitly
-              string.dup.force_encoding("UTF-8").scrub
-            end
+            sanitize_string(string)
           end
         end
 

--- a/lib/vernier/output/top.rb
+++ b/lib/vernier/output/top.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "../output_helpers"
+
 module Vernier
   module Output
     class Top
+      include OutputHelpers
+
       def initialize(profile, row_limit)
         @profile = profile
         @row_limit = row_limit
@@ -57,10 +61,10 @@ module Vernier
             @profile._stack_table
           end
 
-        stack_weights = Hash.new(0)
-        thread[:samples].zip(thread[:weights]) do |stack_idx, weight|
-          stack_weights[stack_idx] += weight
-        end
+        samples = thread[:samples]
+        weights = thread[:weights]
+
+        stack_weights = collapse_stack_weights(samples, weights)
 
         total = stack_weights.values.sum
 

--- a/lib/vernier/output_helpers.rb
+++ b/lib/vernier/output_helpers.rb
@@ -2,6 +2,18 @@
 
 module Vernier
   module OutputHelpers
+    # Collapses parallel samples/weights arrays into a hash of total weight
+    # per stack index. Retained-mode profiles have one sample per object and
+    # many samples share the same stack, so collapsing first keeps later
+    # aggregation proportional to the number of unique stacks.
+    def collapse_stack_weights(samples, weights)
+      stack_weights = Hash.new(0)
+      samples.each_with_index do |stack_idx, idx|
+        stack_weights[stack_idx] += weights[idx]
+      end
+      stack_weights
+    end
+
     # Returns a string safe to embed in JSON output: valid UTF-8 with any
     # invalid bytes replaced. Method names and paths can carry arbitrary
     # encodings (e.g. BINARY or Shift_JIS source), which would otherwise

--- a/lib/vernier/output_helpers.rb
+++ b/lib/vernier/output_helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Vernier
+  module OutputHelpers
+    # Returns a string safe to embed in JSON output: valid UTF-8 with any
+    # invalid bytes replaced. Method names and paths can carry arbitrary
+    # encodings (e.g. BINARY or Shift_JIS source), which would otherwise
+    # raise JSON::GeneratorError.
+    def sanitize_string(string)
+      if string.ascii_only?
+        string
+      elsif string.encoding == Encoding::UTF_8
+        string.valid_encoding? ? string : string.scrub
+      else
+        # We don't know the real encoding; interpret the bytes as UTF-8
+        # and replace anything invalid.
+        string.dup.force_encoding(Encoding::UTF_8).scrub
+      end
+    end
+  end
+end

--- a/test/output/test_file_listing.rb
+++ b/test/output/test_file_listing.rb
@@ -81,6 +81,7 @@ TEXT
     def test_unsampled_interior_stacks
       # Stacks 0 and 1 are never sampled directly, but their frames must
       # still carry the total weight propagated from stack 2.
+
       profile = build_parsed_profile(
         funcs: [["a", "x.rb"], ["b", "x.rb"], ["c", "y.rb"]],
         frames: [[0, 10], [1, 20], [2, 30]],
@@ -125,6 +126,31 @@ TEXT
         Vernier::Output::FileListing.new(profile).samples_by_file
       )
       assert_equal reference_samples_by_file(profile), actual
+    end
+
+    def test_serialized_fixture_is_parent_before_child_ordered
+      profile = Vernier::ParsedProfile.read_file(fixture_path("gvl_sleep.vernier.json"))
+      stack_table = profile.main_thread.stack_table
+
+      stack_table.stack_count.times do |idx|
+        parent = stack_table.stack_parent_idx(idx)
+        assert_operator parent, :<, idx if parent
+      end
+    end
+
+    def test_out_of_order_stack_table_raises
+      profile = build_parsed_profile(
+        funcs: [["a", "x.rb"], ["b", "x.rb"]],
+        frames: [[0, 10], [1, 20]],
+        stacks: [[1, 0], [nil, 1]], # invalid: stack 0's parent is stack 1
+        samples: [0, 1],
+        weights: [1, 1],
+      )
+
+      error = assert_raises(RuntimeError) do
+        Vernier::Output::FileListing.new(profile).samples_by_file
+      end
+      assert_match(/parent-before-child/, error.message)
     end
 
     def test_live_retained_profile_matches_reference

--- a/test/output/test_file_listing.rb
+++ b/test/output/test_file_listing.rb
@@ -57,4 +57,91 @@ TEXT
         " 24.5%   <details style=\"display:inline-block;vertical-align:top;\"><summary>examples/gvl_sleep.rb</summary>\n"
     end
   end
+
+  describe "aggregation" do
+    def test_handcomputed_duplicate_stacks
+      profile = build_parsed_profile(
+        funcs: [["a", "x.rb"], ["b", "x.rb"], ["c", "y.rb"]],
+        frames: [[0, 10], [1, 20], [2, 30]],
+        stacks: [[nil, 0], [0, 1], [1, 2], [0, 2]],
+        samples: [2, 2, 3, 1, 0, 2],
+        weights: [1, 2, 4, 8, 16, 32],
+      )
+
+      listing = Vernier::Output::FileListing.new(profile)
+      assert_equal 63, listing.total
+
+      expected = {
+        "x.rb" => { 10 => [16, 63], 20 => [8, 43] },
+        "y.rb" => { 30 => [39, 39] },
+      }
+      assert_equal expected, normalize_samples_by_file(listing.samples_by_file)
+    end
+
+    def test_unsampled_interior_stacks
+      # Stacks 0 and 1 are never sampled directly, but their frames must
+      # still carry the total weight propagated from stack 2.
+      profile = build_parsed_profile(
+        funcs: [["a", "x.rb"], ["b", "x.rb"], ["c", "y.rb"]],
+        frames: [[0, 10], [1, 20], [2, 30]],
+        stacks: [[nil, 0], [0, 1], [1, 2]],
+        samples: [2, 2],
+        weights: [10, 20],
+      )
+
+      expected = {
+        "x.rb" => { 10 => [0, 30], 20 => [0, 30] },
+        "y.rb" => { 30 => [30, 30] },
+      }
+      assert_equal expected, normalize_samples_by_file(
+        Vernier::Output::FileListing.new(profile).samples_by_file
+      )
+    end
+
+    def test_random_deep_tree_matches_reference
+      rng = Random.new(1234)
+      func_count = 100
+      stack_count = 500
+
+      funcs = Array.new(func_count) { |i| ["func_#{i}", "file_#{i % 3}.rb"] }
+      frames = Array.new(func_count) do |i|
+        [i, rng.rand < 0.1 ? nil : rng.rand(1..100)]
+      end
+      stacks = Array.new(stack_count) do |i|
+        [i == 0 ? nil : rng.rand(i), rng.rand(func_count)]
+      end
+      # Fewer samples than stacks: many stacks stay unsampled, so the
+      # sparse-to-dense scatter is exercised (5000 samples would leave
+      # ~zero stacks unsampled and never test it).
+      samples = Array.new(200) { rng.rand(stack_count) }
+      weights = Array.new(200) { rng.rand(1..500) }
+
+      profile = build_parsed_profile(
+        funcs: funcs, frames: frames, stacks: stacks,
+        samples: samples, weights: weights,
+      )
+
+      actual = normalize_samples_by_file(
+        Vernier::Output::FileListing.new(profile).samples_by_file
+      )
+      assert_equal reference_samples_by_file(profile), actual
+    end
+
+    def test_live_retained_profile_matches_reference
+      retained = []
+      result = Vernier.trace_retained do
+        10.times { retained << Object.new }
+      end
+
+      actual = normalize_samples_by_file(
+        Vernier::Output::FileListing.new(result).samples_by_file
+      )
+      refute_empty actual
+
+      expected = reference_samples_by_file(
+        result, filename_filter: Vernier::Output::FilenameFilter.new
+      )
+      assert_equal expected, actual
+    end
+  end
 end

--- a/test/output/test_top.rb
+++ b/test/output/test_top.rb
@@ -38,4 +38,25 @@ class TestOutputTop < Minitest::Test
     assert_includes output, "| 1989    | 24.5 | Object#ruby_sleep_gvl"
     assert_includes output, "| 10      | 0.1  | Process.clock_gettime"
   end
+
+  def test_duplicate_stacks_match_reference
+    profile = build_parsed_profile(
+      funcs: [["a", "x.rb"], ["b", "x.rb"], ["c", "y.rb"]],
+      frames: [[0, 10], [1, 20], [2, 30]],
+      stacks: [[nil, 0], [0, 1], [1, 2], [0, 2]],
+      samples: [2, 2, 3, 1, 0, 2],
+      weights: [1, 2, 4, 8, 16, 32],
+    )
+
+    output = Vernier::Output::Top.new(profile, 20).output
+
+    expected = reference_top_by_self(profile)
+    assert_equal({ "c" => 39, "a" => 16, "b" => 8 }, expected)
+
+    expected.each do |name, samples|
+      row = output.lines.find { |line| line.split("|").map(&:strip)[3] == name }
+      assert row, "expected a row for #{name.inspect} in:\n#{output}"
+      assert_equal samples.to_s, row.split("|")[1].strip
+    end
+  end
 end

--- a/test/test_custom_sampler.rb
+++ b/test/test_custom_sampler.rb
@@ -14,4 +14,15 @@ class TestCustomSampler < Minitest::Test
     assert_valid_result result
     assert_equal 10, result.total_weights
   end
+
+  def test_custom_result_has_main_thread
+    collector = Vernier::Collector.new(:custom)
+    collector.start
+    collector.sample
+    result = collector.stop
+
+    assert_equal result.threads[0], result.main_thread
+    assert Vernier::Output::Top.new(result, 20).output
+    assert Vernier::Output::FileListing.new(result).output
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,99 @@ class Minitest::Test
     end
   end
 
+  # Reference implementations of the original (pre-optimization) O(samples ×
+  # stack depth) aggregation algorithms, used as oracles to prove the
+  # optimized Output::FileListing and Output::Top produce identical results.
+
+  def reference_samples_by_file(profile, filename_filter: nil)
+    thread = profile.main_thread
+    stack_table =
+      if Hash === thread
+        profile._stack_table
+      else
+        thread.stack_table
+      end
+
+    self_samples_by_frame = Hash.new { |h, k| h[k] = [0, 0] } # frame => [self, total]
+    thread[:samples].zip(thread[:weights]).each do |stack_idx, weight|
+      top_frame_index = stack_table.stack_frame_idx(stack_idx)
+      self_samples_by_frame[top_frame_index][0] += weight
+
+      while stack_idx
+        frame_idx = stack_table.stack_frame_idx(stack_idx)
+        self_samples_by_frame[frame_idx][1] += weight
+        stack_idx = stack_table.stack_parent_idx(stack_idx)
+      end
+    end
+
+    result = Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = [0, 0] } }
+    self_samples_by_frame.each do |frame, (self_weight, total_weight)|
+      line = stack_table.frame_line_no(frame)
+      func_index = stack_table.frame_func_idx(frame)
+      filename = stack_table.func_filename(func_index)
+      filename = filename_filter.call(filename) if filename_filter
+
+      result[filename][line][0] += self_weight
+      result[filename][line][1] += total_weight
+    end
+    result
+  end
+
+  def reference_top_by_self(profile)
+    thread = profile.main_thread
+    stack_table =
+      if Hash === thread
+        profile._stack_table
+      else
+        thread.stack_table
+      end
+
+    result = Hash.new(0)
+    thread[:samples].zip(thread[:weights]).each do |stack_idx, weight|
+      frame_idx = stack_table.stack_frame_idx(stack_idx)
+      func_idx = stack_table.frame_func_idx(frame_idx)
+      result[stack_table.func_name(func_idx)] += weight
+    end
+    result
+  end
+
+  def normalize_samples_by_file(samples_by_file)
+    samples_by_file.transform_values do |lines|
+      lines.transform_values { |location| [location.self, location.total] }
+    end
+  end
+
+  # Builds a minimal gecko-format profile hash suitable for
+  # Vernier::ParsedProfile. +stacks+ is a list of [prefix, frame_idx] pairs
+  # where prefix must always be less than the stack's own index.
+  def build_parsed_profile(funcs:, frames:, stacks:, samples:, weights:)
+    strings = []
+    string_idx = {}
+    intern = ->(str) { string_idx[str] ||= (strings << str; strings.length - 1) }
+
+    Vernier::ParsedProfile.new(
+      "threads" => [{
+        "isMainThread" => true,
+        "name" => "main",
+        "stackTable" => {
+          "prefix" => stacks.map { |prefix, _| prefix },
+          "frame" => stacks.map { |_, frame| frame },
+        },
+        "frameTable" => {
+          "func" => frames.map { |func, _| func },
+          "line" => frames.map { |_, line| line },
+        },
+        "funcTable" => {
+          "name" => funcs.map { |name, _| intern.(name) },
+          "fileName" => funcs.map { |_, file| intern.(file) },
+          "lineNumber" => funcs.map { 1 },
+        },
+        "stringArray" => strings,
+        "samples" => { "stack" => samples, "weight" => weights },
+      }]
+    )
+  end
+
   def encoded_method(encoding, name: "文字化け")
     obj = Object.new
     code = <<~RUBY

--- a/test/test_stack_table.rb
+++ b/test/test_stack_table.rb
@@ -164,6 +164,22 @@ class TestStackTable < Minitest::Test
     assert_includes stack[0].to_s, " at "
   end
 
+  # Output::FileListing's bottom-up aggregation relies on this contract:
+  # stacks are interned parent-before-child, so a stack's parent always has
+  # a lower index.
+  def test_parent_indexes_are_always_lower
+    stack_table = Vernier::StackTable.new
+    1000.times do |i|
+      eval("stack_table.current_stack", binding, "(eval)", i)
+    end
+
+    assert_operator stack_table.stack_count, :>, 1000
+    stack_table.stack_count.times do |idx|
+      parent = stack_table.stack_parent_idx(idx)
+      assert_operator parent, :<, idx if parent
+    end
+  end
+
   def test_backtrace
     stack_table = Vernier::StackTable.new
     expected = caller_locations(0); index = stack_table.current_stack


### PR DESCRIPTION
On a 5MB json.gz file from `retained` mode (~50MB unzipped)
this takes `vernier view` from 15m to 3s on my computer.

The report produced is 1.5MB and is identical before and after.

In adding some tests to ensure the output stayed the same I hit issues with the missing "is_main" fields and the unscrubbed values in cpuprofile so fixed those as well.