### PR TITLE
Pin zlib to >= 3.2.1 in Gemfile to fix CI flakes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem "rake-compiler"
 gem "benchmark-ips"
 
 gem "minitest", "~> 5.0"
+
+gem "zlib", ">= 3.2.1"


### PR DESCRIPTION
Ruby 3.2 still has the older zlib:
https://bugs.ruby-lang.org/issues/20863